### PR TITLE
Remove Configuration property from fluent builders

### DIFF
--- a/src/HatTrick.DbEx.Sql/Builder/ITerminationExpressionBuilder.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/ITerminationExpressionBuilder.cs
@@ -16,14 +16,10 @@
 // The latest version of this file can be found at https://github.com/HatTrickLabs/db-ex
 #endregion
 
-﻿using HatTrick.DbEx.Sql.Configuration;
-using HatTrick.DbEx.Sql.Expression;
 
 namespace HatTrick.DbEx.Sql.Builder
 {
-    public interface ITerminationExpressionBuilder :
-        IExpressionBuilder,
-        IRuntimeSqlDatabaseConfigurationProvider
+    public interface ITerminationExpressionBuilder : IExpressionBuilder
     {
     }
 }

--- a/src/HatTrick.DbEx.Sql/_Extensions/_Builder/SqlExpressionBuilderExtensions.cs
+++ b/src/HatTrick.DbEx.Sql/_Extensions/_Builder/SqlExpressionBuilderExtensions.cs
@@ -4753,7 +4753,8 @@ namespace HatTrick.DbEx.Sql
         #region get database configuration
         private static RuntimeSqlDatabaseConfiguration GetDatabaseConfiguration(this ITerminationExpressionBuilder builder)
         {
-            return builder.Configuration ?? throw new DbExpressionConfigurationException($"Database configuration is required, please review and ensure the correct configuration for DbExpression.");
+            var configProvider = builder as IRuntimeSqlDatabaseConfigurationProvider ?? throw new DbExpressionException($"The provided type {builder.GetType()} is not a configuration provider. {builder.GetType()} must implement {nameof(IRuntimeSqlDatabaseConfigurationProvider)}.");
+            return configProvider.Configuration ?? throw new DbExpressionConfigurationException($"Database configuration is required, please review and ensure the correct configuration for DbExpression.");
         }
         #endregion
 


### PR DESCRIPTION
Removed IRuntimeSqlDatabaseConfigurationProvider from ITerminationExpressionBuilder so the Configuration property would not appear during fluent construction of query expressions.