### PR TITLE
Added missing interfaces to Alias

### DIFF
--- a/src/HatTrick.DbEx.Sql/Expression/AliasExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/AliasExpression.cs
@@ -22,6 +22,8 @@ namespace HatTrick.DbEx.Sql.Expression
 {
     public partial class AliasExpression :
         IExpressionElement,
+        AnyOrderByClause,
+        AnyGroupByClause,
         IEquatable<AliasExpression>
     {
         #region interface


### PR DESCRIPTION
Added missing interfaces to Alias to ensure it can be used with OrderBy and GroupBy clauses.