### PR TITLE
Resolved issue #274

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- issue #274: Scaffolding produces wrong CLR type when providing a configuratio
 
 ### Breaking Changes
 

--- a/tools/HatTrick.DbEx.Tools/Builder/TypeModelBuilder.cs
+++ b/tools/HatTrick.DbEx.Tools/Builder/TypeModelBuilder.cs
@@ -28,7 +28,7 @@ namespace HatTrick.DbEx.Tools.Builder
     {
         private static Func<bool, TypeModel> NewBooleanTypeModel = isNullable => new TypeModel(nameof(Boolean), "bool", isNullable);
         private static Func<bool, TypeModel> NewByteTypeModel = isNullable => new TypeModel(nameof(Byte), "byte", isNullable);
-        private static Func<bool, TypeModel> NewByteArrayTypeModel = isNullable => new TypeModel("ByteArray", "byte[]", false, true);
+        private static Func<bool, TypeModel> NewByteArrayTypeModel = isNullable => new TypeModel("ByteArray", "byte[]", isNullable:false, isEnum:false, isArray:true);
         private static Func<bool, TypeModel> NewDateTimeTypeModel = isNullable => new TypeModel(nameof(DateTime), nameof(DateTime), isNullable);
         private static Func<bool, TypeModel> NewDateTimeOffsetTypeModel = isNullable => new TypeModel(nameof(DateTimeOffset), nameof(DateTimeOffset), isNullable);
         private static Func<bool, TypeModel> NewDecimalTypeModel = isNullable => new TypeModel(nameof(Decimal), "decimal", isNullable);
@@ -104,11 +104,11 @@ namespace HatTrick.DbEx.Tools.Builder
             if (TypeModelFactories.ContainsKey(clrTypeOverride))
                 return TypeModelFactories[clrTypeOverride](isNullable);
 
-            var typeModel = new TypeModel(clrTypeOverride, clrTypeOverride, isNullable, clrTypeOverride.Contains("[]"));
-            typeModel.IsEnum = isEnum;
-            TypeModelFactories.Add(clrTypeOverride, column => typeModel);
+            var nullableTypeModel = new TypeModel(clrTypeOverride, clrTypeOverride, true, isEnum, clrTypeOverride.Contains("[]"));
+            var typeModel = new TypeModel(clrTypeOverride, clrTypeOverride, false, isEnum, clrTypeOverride.Contains("[]"));
+            TypeModelFactories.Add(clrTypeOverride, _isNullable => _isNullable ? nullableTypeModel : typeModel);
 
-            return typeModel;
+            return TypeModelFactories[clrTypeOverride](isNullable);
         }
 
         private static string GetBySqlDbType(SqlDbType sqlType)

--- a/tools/HatTrick.DbEx.Tools/Model/FieldExpressionModel.cs
+++ b/tools/HatTrick.DbEx.Tools/Model/FieldExpressionModel.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Tools.Model
             get
             {
                 if (Type.IsArray)
-                    return (Type.Alias.Substring(0, Type.Alias.Length - 2), "[]");
+                    return (Type.Alias[0..^2], "[]");
                 if (Type.IsNullable)
                     return (Type.Alias, "?");
 

--- a/tools/HatTrick.DbEx.Tools/Model/TypeModel.cs
+++ b/tools/HatTrick.DbEx.Tools/Model/TypeModel.cs
@@ -20,19 +20,20 @@
 {
     public class TypeModel
     { 
-        public string TypeName { get; set; }
-        public string Alias { get; set; }
-        public string NullableAlias { get; set; }
-        public bool IsNullable { get; set; }
-        public bool IsArray { get; set; }
-        public bool IsEnum { get; set; }
+        public string TypeName { get; private set; }
+        public string Alias { get; private set; }
+        public string NullableAlias { get; private set; }
+        public bool IsNullable { get; private set; }
+        public bool IsArray { get; private set; }
+        public bool IsEnum { get; private set; }
 
-        public TypeModel(string typeName, string alias, bool isNullable, bool isArray = false)
+        public TypeModel(string typeName, string alias, bool isNullable, bool isEnum = false, bool isArray = false)
         {
             TypeName = typeName;
             Alias = alias;
             NullableAlias = isNullable ? $"{alias}?" : alias;
             IsNullable = isNullable;
+            IsEnum = isEnum;
             IsArray = isArray;
         }
     }

--- a/tools/HatTrick.DbEx.Tools/Service/Command/Execution/CodeGeneration/CodeGenerateExecutionContext.cs
+++ b/tools/HatTrick.DbEx.Tools/Service/Command/Execution/CodeGeneration/CodeGenerateExecutionContext.cs
@@ -434,8 +434,8 @@ namespace HatTrick.DbEx.Tools.Service
             switch (o.Apply.To.ObjectType)
             {
                 case ObjectType.Any:
-                    SqlModelAccessor accecssor = new SqlModelAccessor(model);
-                    set = accecssor.ResolveItemSet(o.Apply.To.Path);
+                    SqlModelAccessor accessor = new SqlModelAccessor(model);
+                    set = accessor.ResolveItemSet(o.Apply.To.Path);
                     break;
                 case ObjectType.Schema:
                     set = this.ResolveOverrideTarget<MsSqlSchema>(model, o);
@@ -605,17 +605,18 @@ namespace HatTrick.DbEx.Tools.Service
             string[] names = resources.GetTemplateShortNames();
 
             var helpers = new CodeGenerationHelpers(config);
+            var databaseModel = DatabaseModelBuilder.CreateModel(sqlModel, helpers);
 
             for (int i = 0; i < names.Length; i++)
             {
                 var resource = resources.GetTemplate(names[i]);
-                this.RenderOutput(sqlModel, config, resource, helpers);
+                this.RenderOutput(databaseModel, config, resource, helpers);
             }
         }
         #endregion
 
         #region render output
-        protected void RenderOutput(MsSqlModel sqlModel, DbExConfig config, Resource resource, CodeGenerationHelpers helpers)
+        protected void RenderOutput(DatabasePairModel databaseModel, DbExConfig config, Resource resource, CodeGenerationHelpers helpers)
         {
             TemplateEngine engine = new TemplateEngine(resource.Value);
             //engine.ProgressListener += (i, s) =>
@@ -636,7 +637,7 @@ namespace HatTrick.DbEx.Tools.Service
             string output = null;
             try
             {
-                output = engine.Merge(DatabaseModelBuilder.CreateModel(sqlModel, helpers));
+                output = engine.Merge(databaseModel);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Code generation type model factory was a "first wins" for a clr type override, returning the same type model regardless of the number of times and nullable status of the code generator encountered in the model.