### PR TITLE
Distinct in Aggregate Functions

### DIFF
--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/AggregateFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/AggregateFunctionExpression.cs
@@ -20,12 +20,57 @@
 
 namespace HatTrick.DbEx.Sql.Expression
 {
-    public abstract class AggregateFunctionExpression : FunctionExpression
+    public abstract class AggregateFunctionExpression : FunctionExpression,
+        IExpressionIsDistinctProvider,
+        IEquatable<AggregateFunctionExpression>
     {
+        #region internals
+        protected bool IsDistinct { get; set; }
+        #endregion
+
+        #region interface
+        bool IExpressionIsDistinctProvider.IsDistinct => IsDistinct;
+        #endregion
+
         #region constructors
         protected AggregateFunctionExpression(Type declaredType) : base(declaredType)
         {
 
+        }
+        #endregion
+
+        #region distinct
+        public virtual AggregateFunctionExpression Distinct()
+        {
+            IsDistinct = true;
+            return this;
+        }
+        #endregion
+
+        #region equals
+        public bool Equals(AggregateFunctionExpression? obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+
+            if (IsDistinct != obj.IsDistinct) return false;
+
+            return true;
+        }
+
+        public override bool Equals(object? obj)
+         => obj is AggregateFunctionExpression exp && Equals(exp);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                const int multiplier = 16777619;
+
+                int hash = base.GetHashCode();
+                hash = (hash * multiplier) ^ IsDistinct.GetHashCode();
+                return hash;
+            }
         }
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/AverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/AverageFunctionExpression.cs
@@ -22,17 +22,14 @@ namespace HatTrick.DbEx.Sql.Expression
 {
     public abstract class AverageFunctionExpression : AggregateFunctionExpression,
         IExpressionProvider<IExpressionElement>,
-        IExpressionIsDistinctProvider,
         IEquatable<AverageFunctionExpression>
     {
         #region internals
         private readonly IExpressionElement expression;
-        protected bool IsDistinct { get; set; }
         #endregion
 
         #region interface
         IExpressionElement IExpressionProvider<IExpressionElement>.Expression => expression;
-        bool IExpressionIsDistinctProvider.IsDistinct => IsDistinct;
         #endregion
 
         #region constructors
@@ -56,7 +53,7 @@ namespace HatTrick.DbEx.Sql.Expression
             if (expression is not null && obj.expression is null) return false;
             if (expression is not null && !expression.Equals(obj.expression)) return false;
 
-            if (IsDistinct != obj.IsDistinct) return false;
+            if (!base.Equals(obj)) return false;
 
             return true;
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DecimalAverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DecimalAverageFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DecimalAverageFunctionExpression Distinct()
+        public new DecimalAverageFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DoubleAverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/DoubleAverageFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DoubleAverageFunctionExpression Distinct()
+        public new DoubleAverageFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int32AverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int32AverageFunctionExpression.cs
@@ -48,7 +48,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public Int32AverageFunctionExpression Distinct()
+        public new Int32AverageFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int64AverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/Int64AverageFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public Int64AverageFunctionExpression Distinct()
+        public new Int64AverageFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDecimalAverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDecimalAverageFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableDecimalAverageFunctionExpression Distinct()
+        public new NullableDecimalAverageFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDoubleAverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableDoubleAverageFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableDoubleAverageFunctionExpression Distinct()
+        public new NullableDoubleAverageFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt32AverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt32AverageFunctionExpression.cs
@@ -48,7 +48,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableInt32AverageFunctionExpression Distinct()
+        public new NullableInt32AverageFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt64AverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableInt64AverageFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableInt64AverageFunctionExpression Distinct()
+        public new NullableInt64AverageFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableObjectAverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableObjectAverageFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableObjectAverageFunctionExpression Distinct()
+        public new NullableObjectAverageFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableSIngleAverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/NullableSIngleAverageFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableSingleAverageFunctionExpression Distinct()
+        public new NullableSingleAverageFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/SingleAverageFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Average/SingleAverageFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public SingleAverageFunctionExpression Distinct()
+        public new SingleAverageFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/CountFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/CountFunctionExpression.cs
@@ -42,6 +42,14 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
 
+        #region methods
+        public virtual CountFunctionExpression Distinct()
+        {
+            IsDistinct = true;
+            return this;
+        }
+        #endregion
+
         #region to string
         public override string? ToString() => $"COUNT({(IsDistinct ? "DISTINCT " : string.Empty)}{expression})";
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/Int32CountFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/Int32CountFunctionExpression.cs
@@ -43,7 +43,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public Int32CountFunctionExpression Distinct()
+        public new Int32CountFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/NullableObjectCountFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Count/NullableObjectCountFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableObjectCountFunctionExpression Distinct()
+        public new NullableObjectCountFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/ByteMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/ByteMaximumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public ByteMaximumFunctionExpression Distinct()
+        public new ByteMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeMaximumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DateTimeMaximumFunctionExpression Distinct()
+        public new DateTimeMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeOffsetMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DateTimeOffsetMaximumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DateTimeOffsetMaximumFunctionExpression Distinct()
+        public new DateTimeOffsetMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DecimalMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DecimalMaximumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DecimalMaximumFunctionExpression Distinct()
+        public new DecimalMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DoubleMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/DoubleMaximumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DoubleMaximumFunctionExpression Distinct()
+        public new DoubleMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/GuidMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/GuidMaximumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public GuidMaximumFunctionExpression Distinct()
+        public new GuidMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int16MaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int16MaximumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public Int16MaximumFunctionExpression Distinct()
+        public new Int16MaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int32MaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int32MaximumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public Int32MaximumFunctionExpression Distinct()
+        public new Int32MaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int64MaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/Int64MaximumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public Int64MaximumFunctionExpression Distinct()
+        public new Int64MaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/MaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/MaximumFunctionExpression.cs
@@ -42,6 +42,14 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
 
+        #region methods
+        public virtual MaximumFunctionExpression Distinct()
+        {
+            IsDistinct = true;
+            return this;
+        }
+        #endregion
+
         #region to string
         public override string? ToString() => $"MAX({(IsDistinct ? "DISTINCT " : string.Empty)}{expression})";
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableByteMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableByteMaximumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableByteMaximumFunctionExpression Distinct()
+        public new NullableByteMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeMaximumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableDateTimeMaximumFunctionExpression Distinct()
+        public new NullableDateTimeMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeOffsetMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDateTimeOffsetMaximumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableDateTimeOffsetMaximumFunctionExpression Distinct()
+        public new NullableDateTimeOffsetMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDecimalMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDecimalMaximumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableDecimalMaximumFunctionExpression Distinct()
+        public new NullableDecimalMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDoubleMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableDoubleMaximumFunctionExpression.cs
@@ -39,12 +39,13 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableDoubleMaximumFunctionExpression Distinct()
+        public new NullableDoubleMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;
         }
         #endregion
+
         #region equals
         public bool Equals(NullableDoubleMaximumFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableGuidMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableGuidMaximumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableGuidMaximumFunctionExpression Distinct()
+        public new NullableGuidMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt16MaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt16MaximumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableInt16MaximumFunctionExpression Distinct()
+        public new NullableInt16MaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt32MaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt32MaximumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableInt32MaximumFunctionExpression Distinct()
+        public new NullableInt32MaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt64MaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableInt64MaximumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableInt64MaximumFunctionExpression Distinct()
+        public new NullableInt64MaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableObjectMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableObjectMaximumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableObjectMaximumFunctionExpression Distinct()
+        public new NullableObjectMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableSingleMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableSingleMaximumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableSingleMaximumFunctionExpression Distinct()
+        public new NullableSingleMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableTimeSpanMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/NullableTimeSpanMaximumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableTimeSpanMaximumFunctionExpression Distinct()
+        public new NullableTimeSpanMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/SingleMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/SingleMaximumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public SingleMaximumFunctionExpression Distinct()
+        public new SingleMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/StringMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/StringMaximumFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public StringMaximumFunctionExpression Distinct()
+        public new StringMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/TimeSpanMaximumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Maximum/TimeSpanMaximumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public TimeSpanMaximumFunctionExpression Distinct()
+        public new TimeSpanMaximumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/ByteMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/ByteMinimumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public ByteMinimumFunctionExpression Distinct()
+        public new ByteMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeMinimumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DateTimeMinimumFunctionExpression Distinct()
+        public new DateTimeMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeOffsetMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DateTimeOffsetMinimumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DateTimeOffsetMinimumFunctionExpression Distinct()
+        public new DateTimeOffsetMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DecimalMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DecimalMinimumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DecimalMinimumFunctionExpression Distinct()
+        public new DecimalMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DoubleMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/DoubleMinimumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DoubleMinimumFunctionExpression Distinct()
+        public new DoubleMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/GuidMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/GuidMinimumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public GuidMinimumFunctionExpression Distinct()
+        public new GuidMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int16MinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int16MinimumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public Int16MinimumFunctionExpression Distinct()
+        public new Int16MinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int32MinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int32MinimumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public Int32MinimumFunctionExpression Distinct()
+        public new Int32MinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int64MinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/Int64MinimumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public Int64MinimumFunctionExpression Distinct()
+        public new Int64MinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/MinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/MinimumFunctionExpression.cs
@@ -42,6 +42,14 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
 
+        #region distinct
+        public virtual MinimumFunctionExpression Distinct()
+        {
+            IsDistinct = true;
+            return this;
+        }
+        #endregion
+
         #region to string
         public override string? ToString() => $"MIN({(IsDistinct ? "DISTINCT " : string.Empty)}{expression})";
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableByteMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableByteMinimumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableByteMinimumFunctionExpression Distinct()
+        public new NullableByteMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeMinimumFunctionExpression.cs
@@ -37,8 +37,9 @@ namespace HatTrick.DbEx.Sql.Expression
         public AnyElement<DateTime?> As(string alias)
             => new SelectExpression<DateTime?>(this).As(alias);
         #endregion
+
         #region distinct
-        public NullableDateTimeMinimumFunctionExpression Distinct()
+        public new NullableDateTimeMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeOffsetMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDateTimeOffsetMinimumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableDateTimeOffsetMinimumFunctionExpression Distinct()
+        public new NullableDateTimeOffsetMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDecimalMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDecimalMinimumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableDecimalMinimumFunctionExpression Distinct()
+        public new NullableDecimalMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDoubleMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableDoubleMinimumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableDoubleMinimumFunctionExpression Distinct()
+        public new NullableDoubleMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableGuidMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableGuidMinimumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableGuidMinimumFunctionExpression Distinct()
+        public new NullableGuidMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt16MinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt16MinimumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableInt16MinimumFunctionExpression Distinct()
+        public new NullableInt16MinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt32MinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt32MinimumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableInt32MinimumFunctionExpression Distinct()
+        public new NullableInt32MinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt64MinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableInt64MinimumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableInt64MinimumFunctionExpression Distinct()
+        public new NullableInt64MinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableObjectMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableObjectMinimumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableObjectMinimumFunctionExpression Distinct()
+        public new NullableObjectMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableSingleMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableSingleMinimumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableSingleMinimumFunctionExpression Distinct()
+        public new NullableSingleMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableTimeSpanMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/NullableTimeSpanMinimumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableTimeSpanMinimumFunctionExpression Distinct()
+        public new NullableTimeSpanMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/SingleMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/SingleMinimumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public SingleMinimumFunctionExpression Distinct()
+        public new SingleMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/StringMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/StringMinimumFunctionExpression.cs
@@ -43,7 +43,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public StringMinimumFunctionExpression Distinct()
+        public new StringMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/TimeSpanMinimumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Minimum/TimeSpanMinimumFunctionExpression.cs
@@ -33,7 +33,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public TimeSpanMinimumFunctionExpression Distinct()
+        public new TimeSpanMinimumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/NullableSinglePopulationStandardDeviationFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/NullableSinglePopulationStandardDeviationFunctionExpression.cs
@@ -66,7 +66,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableSinglePopulationStandardDeviationFunctionExpression Distinct()
+        public new NullableSinglePopulationStandardDeviationFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/PopulationStandardDeviationFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/PopulationStandardDeviationFunctionExpression.cs
@@ -42,6 +42,14 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
 
+        #region distinct
+        public virtual PopulationStandardDeviationFunctionExpression Distinct()
+        {
+            IsDistinct = true;
+            return this;
+        }
+        #endregion
+
         #region to string
         public override string? ToString() => $"STDEVP({(IsDistinct ? "DISTINCT " : string.Empty)}{expression})";
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/SinglePopulationStandardDeviationFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationStandardDeviation/SinglePopulationStandardDeviationFunctionExpression.cs
@@ -66,7 +66,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public SinglePopulationStandardDeviationFunctionExpression Distinct()
+        public new SinglePopulationStandardDeviationFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/NullableSinglePopulationVarianceFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/NullableSinglePopulationVarianceFunctionExpression.cs
@@ -68,7 +68,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableSinglePopulationVarianceFunctionExpression Distinct()
+        public new NullableSinglePopulationVarianceFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/PopulationVarianceFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/PopulationVarianceFunctionExpression.cs
@@ -42,6 +42,14 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
 
+        #region distinct
+        public virtual PopulationVarianceFunctionExpression Distinct()
+        {
+            IsDistinct = true;
+            return this;
+        }
+        #endregion
+
         #region to string
         public override string? ToString() => $"VARP({(IsDistinct ? "DISTINCT " : string.Empty)}{expression})";
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/SinglePopulationVarianceFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_PopulationVariance/SinglePopulationVarianceFunctionExpression.cs
@@ -68,7 +68,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public SinglePopulationVarianceFunctionExpression Distinct()
+        public new SinglePopulationVarianceFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/NullableSingleStandardDeviationFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/NullableSingleStandardDeviationFunctionExpression.cs
@@ -68,7 +68,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableSingleStandardDeviationFunctionExpression Distinct()
+        public new NullableSingleStandardDeviationFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/SingleStandardDeviationFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/SingleStandardDeviationFunctionExpression.cs
@@ -68,7 +68,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public SingleStandardDeviationFunctionExpression Distinct()
+        public new SingleStandardDeviationFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/StandardDeviationFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_StandardDeviation/StandardDeviationFunctionExpression.cs
@@ -42,6 +42,14 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
 
+        #region distinct
+        public virtual StandardDeviationFunctionExpression Distinct()
+        {
+            IsDistinct = true;
+            return this;
+        }
+        #endregion
+
         #region to string
         public override string? ToString() => $"STDEV({(IsDistinct ? "DISTINCT " : string.Empty)}{expression})";
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DecimalSumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DecimalSumFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DecimalSumFunctionExpression Distinct()
+        public new DecimalSumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DoubleSumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/DoubleSumFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public DoubleSumFunctionExpression Distinct()
+        public new DoubleSumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int32SumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int32SumFunctionExpression.cs
@@ -48,7 +48,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public Int32SumFunctionExpression Distinct()
+        public new Int32SumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int64SumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/Int64SumFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public Int64SumFunctionExpression Distinct()
+        public new Int64SumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDecimalSumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDecimalSumFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableDecimalSumFunctionExpression Distinct()
+        public new NullableDecimalSumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDoubleSumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableDoubleSumFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableDoubleSumFunctionExpression Distinct()
+        public new NullableDoubleSumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt32SumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt32SumFunctionExpression.cs
@@ -48,7 +48,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableInt32SumFunctionExpression Distinct()
+        public new NullableInt32SumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt64SumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableInt64SumFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableInt64SumFunctionExpression Distinct()
+        public new NullableInt64SumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableObjectSumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableObjectSumFunctionExpression.cs
@@ -39,7 +39,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableObjectSumFunctionExpression Distinct()
+        public new NullableObjectSumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableSIngleSumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/NullableSIngleSumFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableSingleSumFunctionExpression Distinct()
+        public new NullableSingleSumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/SingleSumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/SingleSumFunctionExpression.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public SingleSumFunctionExpression Distinct()
+        public new SingleSumFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/SumFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Sum/SumFunctionExpression.cs
@@ -42,6 +42,14 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
 
+        #region distinct
+        public virtual SumFunctionExpression Distinct()
+        {
+            IsDistinct = true;
+            return this;
+        }
+        #endregion
+
         #region to string
         public override string? ToString() => $"SUM({(IsDistinct ? "DISTINCT " : string.Empty)}{expression})";
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/NullableSIngleVarianceFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/NullableSIngleVarianceFunctionExpression.cs
@@ -68,7 +68,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public NullableSingleVarianceFunctionExpression Distinct()
+        public new NullableSingleVarianceFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/SingleVarianceFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/SingleVarianceFunctionExpression.cs
@@ -68,7 +68,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region distinct
-        public SingleVarianceFunctionExpression Distinct()
+        public new SingleVarianceFunctionExpression Distinct()
         {
             IsDistinct = true;
             return this;

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/VarianceFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_Aggregate/_Variance/VarianceFunctionExpression.cs
@@ -42,6 +42,14 @@ namespace HatTrick.DbEx.Sql.Expression
         }
         #endregion
 
+        #region distinct
+        public virtual VarianceFunctionExpression Distinct()
+        {
+            IsDistinct = true;
+            return this;
+        }
+        #endregion
+
         #region to string
         public override string? ToString() => $"VAR({(IsDistinct ? "DISTINCT " : string.Empty)}{expression})";
         #endregion

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/AbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/AbsFunctionExpression.cs
@@ -22,17 +22,14 @@ namespace HatTrick.DbEx.Sql.Expression
 {
     public abstract class AbsFunctionExpression : AggregateFunctionExpression,
         IExpressionProvider<IExpressionElement>,
-        IExpressionIsDistinctProvider,
         IEquatable<AbsFunctionExpression>
     {
         #region internals
         private readonly IExpressionElement expression;
-        protected bool IsDistinct { get; set; }
         #endregion
 
         #region interface
         IExpressionElement IExpressionProvider<IExpressionElement>.Expression => expression;
-        bool IExpressionIsDistinctProvider.IsDistinct => IsDistinct;
         #endregion
 
         #region constructors
@@ -43,7 +40,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region to string
-        public override string? ToString() => $"MIN({(IsDistinct ? "DISTINCT " : string.Empty)}{expression})";
+        public override string? ToString() => $"ABS({expression})";
         #endregion
 
         #region equals
@@ -55,8 +52,6 @@ namespace HatTrick.DbEx.Sql.Expression
             if (expression is null && obj.expression is not null) return false;
             if (expression is not null && obj.expression is null) return false;
             if (expression is not null && !expression.Equals(obj.expression)) return false;
-
-            if (IsDistinct != obj.IsDistinct) return false;
 
             return true;
         }
@@ -72,7 +67,6 @@ namespace HatTrick.DbEx.Sql.Expression
 
                 int hash = base.GetHashCode();
                 hash = (hash * multiplier) ^ (expression is not null ? expression.GetHashCode() : 0);
-                hash = (hash * multiplier) ^ IsDistinct.GetHashCode();
                 return hash;
             }
         }

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/ByteAbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/ByteAbsFunctionExpression.cs
@@ -37,14 +37,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<byte>(this).As(alias);
         #endregion
 
-        #region distinct
-        public ByteAbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(ByteAbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/DecimalAbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/DecimalAbsFunctionExpression.cs
@@ -37,14 +37,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<decimal>(this).As(alias);
         #endregion
 
-        #region distinct
-        public DecimalAbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(DecimalAbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/DoubleAbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/DoubleAbsFunctionExpression.cs
@@ -37,14 +37,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<double>(this).As(alias);
         #endregion
 
-        #region distinct
-        public DoubleAbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(DoubleAbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/Int16AbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/Int16AbsFunctionExpression.cs
@@ -37,14 +37,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<short>(this).As(alias);
         #endregion
 
-        #region distinct
-        public Int16AbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(Int16AbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/Int32AbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/Int32AbsFunctionExpression.cs
@@ -37,14 +37,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<int>(this).As(alias);
         #endregion
 
-        #region distinct
-        public Int32AbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(Int32AbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/Int64AbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/Int64AbsFunctionExpression.cs
@@ -37,14 +37,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<long>(this).As(alias);
         #endregion
 
-        #region distinct
-        public Int64AbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(Int64AbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableByteAbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableByteAbsFunctionExpression.cs
@@ -38,14 +38,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<byte?>(this).As(alias);
         #endregion
 
-        #region distinct
-        public NullableByteAbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(NullableByteAbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableDecimalAbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableDecimalAbsFunctionExpression.cs
@@ -38,14 +38,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<decimal?>(this).As(alias);
         #endregion
 
-        #region distinct
-        public NullableDecimalAbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(NullableDecimalAbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableDoubleAbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableDoubleAbsFunctionExpression.cs
@@ -38,14 +38,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<double?>(this).As(alias);
         #endregion
 
-        #region distinct
-        public NullableDoubleAbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(NullableDoubleAbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableInt16AbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableInt16AbsFunctionExpression.cs
@@ -38,14 +38,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<short?>(this).As(alias);
         #endregion
 
-        #region distinct
-        public NullableInt16AbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(NullableInt16AbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableInt32AbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableInt32AbsFunctionExpression.cs
@@ -38,14 +38,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<int?>(this).As(alias);
         #endregion
 
-        #region distinct
-        public NullableInt32AbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(NullableInt32AbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableInt64AbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableInt64AbsFunctionExpression.cs
@@ -38,14 +38,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<long?>(this).As(alias);
         #endregion
 
-        #region distinct
-        public NullableInt64AbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(NullableInt64AbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableSingleAbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/NullableSingleAbsFunctionExpression.cs
@@ -38,14 +38,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<float?>(this).As(alias);
         #endregion
 
-        #region distinct
-        public NullableSingleAbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(NullableSingleAbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);

--- a/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/SingleAbsFunctionExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/_Function/_DataType/_Abs/SingleAbsFunctionExpression.cs
@@ -37,14 +37,6 @@ namespace HatTrick.DbEx.Sql.Expression
             => new SelectExpression<float>(this).As(alias);
         #endregion
 
-        #region distinct
-        public SingleAbsFunctionExpression Distinct()
-        {
-            IsDistinct = true;
-            return this;
-        }
-        #endregion
-
         #region equals
         public bool Equals(SingleAbsFunctionExpression? obj)
             => obj is not null && base.Equals(obj);


### PR DESCRIPTION
Moved Distinct to root of aggregate functions to ensure all aggregate functions have a distinct.  Removed Distinct from ABS function as ABS doesn't support Distinct.