### PR TITLE
Configuration syntax changes, Alias expression changes

### DIFF
--- a/samples/mssql/NetCoreConsoleApp/Program.cs
+++ b/samples/mssql/NetCoreConsoleApp/Program.cs
@@ -67,12 +67,12 @@ namespace NetCoreConsoleApp
                     database =>
                     {
                         database.ConnectionString.Use(config.GetConnectionString("dbex_mssql_test"));
-                        database.SqlStatements.Assembly.ConfigureOutputSettings(x => x.PrependCommaOnSelectClause = false);
+                        database.SqlStatements.Assembly.ConfigureAssemblyOptions(x => x.PrependCommaOnSelectClause = false);
                         database.Conversions.ForTypes(x =>
                             x.ForEnumType<PaymentMethodType>().PersistAsString()
                              .ForEnumType<PaymentSourceType>().PersistAsString()
                         );
-                        database.Logging.ConfigureLoggingSettings(l => l.LogParameterValues = true);
+                        database.Logging.ConfigureLoggingOptions(l => l.LogParameterValues = true);
                     }
                 );
 

--- a/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Creation/EntityFactoryConfigurationBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Creation/EntityFactoryConfigurationBuilder{T}.cs
@@ -58,6 +58,16 @@ namespace HatTrick.DbEx.Sql.Configuration
         }
 
         /// <inheritdoc />
+        public IEntitiesConfigurationBuilderMappingGrouping<TDatabase> Use(Func<IEntityFactory> factory)
+        {
+            if (factory is null)
+                throw new ArgumentNullException(nameof(factory));
+
+            services.TryAddSingleton(factory);
+            return caller;
+        }
+
+        /// <inheritdoc />
         public IEntitiesConfigurationBuilderMappingGrouping<TDatabase> Use<TEntityFactory>()
             where TEntityFactory : class, IEntityFactory
         {

--- a/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Creation/IEntityFactoryConfigurationBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Creation/IEntityFactoryConfigurationBuilder{T}.cs
@@ -38,6 +38,11 @@ namespace HatTrick.DbEx.Sql.Configuration
         /// <summary>
         /// Use a custom factory to create an entity prior to mapping data retrieved from the target database.
         /// </summary>
+        IEntitiesConfigurationBuilderMappingGrouping<TDatabase> Use(Func<IEntityFactory> factory);
+
+        /// <summary>
+        /// Use a custom factory to create an entity prior to mapping data retrieved from the target database.
+        /// </summary>
         /// <param name="factory">A delegate responsible for creating an <see cref="IDbEntity"/>.</param>
         IEntitiesConfigurationBuilderMappingGrouping<TDatabase> Use(Func<Type, IDbEntity> factory);
 

--- a/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/EntityTypeMapperContinuationConfigurationBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/EntityTypeMapperContinuationConfigurationBuilder{T,U}.cs
@@ -1,0 +1,60 @@
+﻿using HatTrick.DbEx.Sql.Executor;
+using HatTrick.DbEx.Sql.Mapper;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HatTrick.DbEx.Sql.Configuration
+{
+    public class EntityTypeMapperContinuationConfigurationBuilder<TDatabase, TEntity> : IEntityTypeMapperContinuationConfigurationBuilder<TDatabase, TEntity>
+        where TDatabase : class, ISqlDatabaseRuntime
+        where TEntity : class, IDbEntity
+    {
+        private readonly IEntityMapperContinuationConfigurationBuilder<TDatabase> caller;
+        private readonly IServiceCollection services;
+
+        public EntityTypeMapperContinuationConfigurationBuilder(IEntityMapperContinuationConfigurationBuilder<TDatabase> caller, IServiceCollection services)
+        {
+            this.caller = caller ?? throw new ArgumentNullException(nameof(caller));
+            this.services = services ?? throw new ArgumentNullException(nameof(services));
+        }
+
+        /// <inheritdoc/>
+        public IEntityMapperContinuationConfigurationBuilder<TDatabase> Use(Action<ISqlFieldReader, TEntity> mapping)
+        {
+            services.TryAddSingleton<IEntityMapper<TEntity>>(new EntityMapper<TEntity>(mapping));
+            return caller;
+        }
+
+        /// <inheritdoc/>
+        public IEntityMapperContinuationConfigurationBuilder<TDatabase> Use<T>()
+            where T : class, IEntityMapper<TEntity>
+        {
+            services.TryAddSingleton<IEntityMapper<TEntity>, T>();
+            return caller;
+        }
+
+        /// <inheritdoc/>
+        public IEntityMapperContinuationConfigurationBuilder<TDatabase> Use(IEntityMapper<TEntity> mapper)
+        {
+            services.TryAddSingleton<IEntityMapper<TEntity>>(mapper);
+            return caller;
+        }
+
+        /// <inheritdoc/>
+        public IEntityMapperContinuationConfigurationBuilder<TDatabase> Use(Func<IEntityMapper<TEntity>> factory)
+        {
+            services.TryAddSingleton<IEntityMapper<TEntity>>(sp => factory());
+            return caller;
+        }
+
+        /// <inheritdoc/>
+        public IEntityMapperContinuationConfigurationBuilder<TDatabase> Use(Func<IServiceProvider, IEntityMapper<TEntity>> factory)
+        {
+            services.TryAddSingleton<IEntityMapper<TEntity>>(factory);
+            return caller;
+        }
+    }
+}

--- a/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/IEntityMapperContinuationConfigurationBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/IEntityMapperContinuationConfigurationBuilder{T}.cs
@@ -17,11 +17,12 @@
 #endregion
 
 ﻿using HatTrick.DbEx.Sql.Executor;
+using HatTrick.DbEx.Sql.Mapper;
 using System;
 
 namespace HatTrick.DbEx.Sql.Configuration
 {
-    public interface IMapperFactoryContinuationConfigurationBuilder<TDatabase>
+    public interface IEntityMapperContinuationConfigurationBuilder<TDatabase>
         where TDatabase : class, ISqlDatabaseRuntime
     {
         /// <summary>
@@ -29,7 +30,7 @@ namespace HatTrick.DbEx.Sql.Configuration
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         /// <param name="mapping">The delegate that iterates a field reader and maps the field values to <typeparamref name="TEntity"/> properties.</typeparam>
-        IMapperFactoryContinuationConfigurationBuilder<TDatabase> ForEntityType<TEntity>(Action<ISqlFieldReader, TEntity> mapping)
+        IEntityTypeMapperContinuationConfigurationBuilder<TDatabase, TEntity> ForEntityType<TEntity>()
             where TEntity : class, IDbEntity;        
     }
 }

--- a/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/IEntityTypeMapperContinuationConfigurationBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/IEntityTypeMapperContinuationConfigurationBuilder{T,U}.cs
@@ -1,0 +1,46 @@
+﻿using HatTrick.DbEx.Sql.Executor;
+using HatTrick.DbEx.Sql.Mapper;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HatTrick.DbEx.Sql.Configuration
+{
+    public interface IEntityTypeMapperContinuationConfigurationBuilder<TDatabase, TEntity>
+        where TDatabase : class, ISqlDatabaseRuntime
+        where TEntity : class, IDbEntity
+    {
+        /// <summary>
+        /// Override the default behaviour of mapping retrieved rowsets from the database to a <typeparamref name="TEntity"/> instance. 
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="mapping">The delegate that iterates a field reader and maps the field values to <typeparamref name="TEntity"/> properties.</typeparam>
+        IEntityMapperContinuationConfigurationBuilder<TDatabase> Use(Action<ISqlFieldReader, TEntity> mapping);
+
+        /// <summary>
+        /// Override the default behaviour of mapping retrieved rowsets from the database to a <typeparamref name="TEntity"/> instance. 
+        /// </summary>
+        /// <typeparam name="T">The entity mapper type to use for mapping data to an <see cref="TEntity"/>.</typeparam>
+        IEntityMapperContinuationConfigurationBuilder<TDatabase> Use<T>()
+            where T : class, IEntityMapper<TEntity>;
+
+        /// <summary>
+        /// Override the default behaviour of mapping retrieved rowsets from the database to a <typeparamref name="TEntity"/> instance. 
+        /// </summary>
+        /// <param name="mapper">The entity mapper to use for mapping data to an <see cref="TEntity"/>.</param>
+        IEntityMapperContinuationConfigurationBuilder<TDatabase> Use(IEntityMapper<TEntity> mapper);
+
+        /// <summary>
+        /// Override the default behaviour of mapping retrieved rowsets from the database to a <typeparamref name="TEntity"/> instance. 
+        /// </summary>
+        /// <param name="factory">A delegate that returns an entity mapper to use for mapping data to an <see cref="TEntity"/>.</param>
+        IEntityMapperContinuationConfigurationBuilder<TDatabase> Use(Func<IEntityMapper<TEntity>> factory);
+
+        /// <summary>
+        /// Override the default behaviour of mapping retrieved rowsets from the database to a <typeparamref name="TEntity"/> instance. 
+        /// </summary>
+        /// <param name="factory">A delegate that returns an entity mapper to use for mapping data to an <see cref="TEntity"/>.</param>
+        IEntityMapperContinuationConfigurationBuilder<TDatabase> Use(Func<IServiceProvider, IEntityMapper<TEntity>> factory);
+    }
+}

--- a/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/IMapperFactoryConfigurationBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Mapping/IMapperFactoryConfigurationBuilder{T}.cs
@@ -16,7 +16,7 @@
 // The latest version of this file can be found at https://github.com/HatTrickLabs/db-ex
 #endregion
 
-﻿using HatTrick.DbEx.Sql.Mapper;
+using HatTrick.DbEx.Sql.Mapper;
 using System;
 
 namespace HatTrick.DbEx.Sql.Configuration
@@ -25,15 +25,20 @@ namespace HatTrick.DbEx.Sql.Configuration
         where TDatabase : class, ISqlDatabaseRuntime
     {
         /// <summary>
-        /// Use a custom factory to create a <see cref="IEntityMapper"/> used to map data retrieved from the target database.
+        /// Use a custom factory to create a <see cref="IMapperFactory"/> used to map data retrieved from the target database.
         /// </summary>
         IEntitiesConfigurationBuilderCreationGrouping<TDatabase> Use(IMapperFactory factory);
 
         /// <summary>
-        /// Use a custom factory to create a <see cref="IEntityMapper"/> used to map data retrieved from the target database.
+        /// Use a custom <see cref="IMapperFactory"/> to map data retrieved from the target database.
         /// </summary>
         IEntitiesConfigurationBuilderCreationGrouping<TDatabase> Use<TMapperFactory>()
             where TMapperFactory : class, IMapperFactory;
+
+        /// <summary>
+        /// Use a custom <see cref="IMapperFactory"/>.
+        /// </summary>
+        IEntitiesConfigurationBuilderCreationGrouping<TDatabase> Use(Func<IMapperFactory> factory);
 
         /// <summary>
         /// Use a custom factory to create a <see cref="IEntityMapper"/> used to map data retrieved from the target database.
@@ -48,9 +53,15 @@ namespace HatTrick.DbEx.Sql.Configuration
         IEntitiesConfigurationBuilderCreationGrouping<TDatabase> Use(Func<IServiceProvider, Type, IEntityMapper> factory);
 
         /// <summary>
-        /// Use a custom factory to create a <see cref="IEntityMapper"/> used to map data retrieved from the target database.
+        /// Use the service provider to resolve a <see cref="IMapperFactory"/>.
         /// </summary>
-        /// <param name="factory">A delegate responsible for creating an <see cref="IEntityMapper"/>.</param>
+        /// <param name="factory">A delegate responsible for creating an <see cref="IMapperFactory"/>.</param>
         IEntitiesConfigurationBuilderCreationGrouping<TDatabase> Use(Func<IServiceProvider, IMapperFactory> factory);
+
+        /// <summary>
+        /// Override the default behaviour of mapping retrieved rowsets from the database for specific entity types. 
+        /// </summary>
+        /// <param name="configureEntityTypes">The delegate to configure mapping for specific entity types.</typeparam>
+        IEntityMapperContinuationConfigurationBuilder<TDatabase> ForEntityTypes(Action<IEntityMapperContinuationConfigurationBuilder<TDatabase>> configureEntityTypes);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Configuration/_Logging/ILoggingOptionsBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Logging/ILoggingOptionsBuilder{T}.cs
@@ -23,6 +23,6 @@ namespace HatTrick.DbEx.Sql.Configuration
     public interface ILoggingOptionsBuilder<TDatabase>
         where TDatabase : class, ISqlDatabaseRuntime
     {
-        ISqlDatabaseRuntimeConfigurationBuilder<TDatabase> ConfigureLoggingSettings(Action<LoggingOptions> configure);
+        ISqlDatabaseRuntimeConfigurationBuilder<TDatabase> ConfigureLoggingOptions(Action<LoggingOptions> configure);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Configuration/_Logging/LoggingOptionsBuilder.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Logging/LoggingOptionsBuilder.cs
@@ -41,7 +41,7 @@ namespace HatTrick.DbEx.Sql.Configuration
 
         #region methods
         /// <inheritdoc />
-        public ISqlDatabaseRuntimeConfigurationBuilder<TDatabase> ConfigureLoggingSettings(Action<LoggingOptions> configure)
+        public ISqlDatabaseRuntimeConfigurationBuilder<TDatabase> ConfigureLoggingOptions(Action<LoggingOptions> configure)
         {
             if (configure is null)
                 throw new ArgumentNullException(nameof(configure));

--- a/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/SqlStatementAssemblyGroupingConfigurationBuilders{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/SqlStatementAssemblyGroupingConfigurationBuilders{T}.cs
@@ -58,7 +58,7 @@ namespace HatTrick.DbEx.Sql.Configuration
 
         #region methods
         /// <inheritdoc />
-        public ISqlStatementAssemblyGroupingConfigurationBuilders<TDatabase> ConfigureOutputSettings(Action<SqlStatementAssemblyOptions> config)
+        public ISqlStatementAssemblyGroupingConfigurationBuilders<TDatabase> ConfigureAssemblyOptions(Action<SqlStatementAssemblyOptions> config)
         {
             if (config is null)
                 throw new ArgumentNullException(nameof(config));

--- a/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/_Assembly/IExpressionElementAppenderFactoryConfigurationBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/_Assembly/IExpressionElementAppenderFactoryConfigurationBuilder{T}.cs
@@ -50,6 +50,11 @@ namespace HatTrick.DbEx.Sql.Configuration
         /// <summary>
         /// Use a custom factory for creating an expression element appender for appending the element's state to a sql statement writer.
         /// </summary>
+        ISqlStatementAssemblyGroupingConfigurationBuilders<TDatabase> Use(Func<IExpressionElementAppenderFactory> factory);
+
+        /// <summary>
+        /// Use a custom factory for creating an expression element appender for appending the element's state to a sql statement writer.
+        /// </summary>
         ISqlStatementAssemblyGroupingConfigurationBuilders<TDatabase> Use(Func<IServiceProvider, IExpressionElementAppenderFactory> factory);
 
         /// <summary>

--- a/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/_Assembly/ISqlStatementAssemblyGroupingConfigurationBuilders{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/_Assembly/ISqlStatementAssemblyGroupingConfigurationBuilders{T}.cs
@@ -47,6 +47,6 @@ namespace HatTrick.DbEx.Sql.Configuration
         /// Configure the settings used to construct a sql statement.
         /// </summary>
         /// <param name="configure">Configure the settings used while constructing sql statements.</param>
-        ISqlStatementAssemblyGroupingConfigurationBuilders<TDatabase> ConfigureOutputSettings(Action<SqlStatementAssemblyOptions> configure);
+        ISqlStatementAssemblyGroupingConfigurationBuilders<TDatabase> ConfigureAssemblyOptions(Action<SqlStatementAssemblyOptions> configure);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/_Assembly/SqlStatementBuilderFactoryConfigurationBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/_Assembly/SqlStatementBuilderFactoryConfigurationBuilder{T}.cs
@@ -20,6 +20,7 @@ using HatTrick.DbEx.Sql.Assembler;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
+using System.Collections.Generic;
 
 namespace HatTrick.DbEx.Sql.Configuration
 {

--- a/src/HatTrick.DbEx.Sql/Expression/IEntityExpression{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/IEntityExpression{T}.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // Copyright (c) HatTrick Labs, LLC.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,8 +20,9 @@ using System.Collections.Generic;
 
 namespace HatTrick.DbEx.Sql.Expression
 {
-    public interface IEntityExpression : IExpressionElement 
+    public interface IEntityExpression<T> : IEntityExpression
+        where T : class, IDbEntity
     {
-        IEnumerable<IExpressionElement> Expressions { get; }
+
     }
 }

--- a/src/HatTrick.DbEx.Sql/dbex.cs
+++ b/src/HatTrick.DbEx.Sql/dbex.cs
@@ -59,7 +59,7 @@ namespace HatTrick.DbEx.Sql
         /// <remarks>This version is required when creating aliases of any element that equates to a <see cref="String"/> type (<see cref="AnyStringElement"/> element).</remarks>
         public static AliasExpression<object?> Alias(string tableName, string fieldName)
             => new((tableName, fieldName));
-
+         
         /// <summary>
         /// Create an alias for use with other expressions.  Typically, these are expressions like order by clauses and group by clauses (although you can use the generic form as well).
         /// </summary>
@@ -73,7 +73,7 @@ namespace HatTrick.DbEx.Sql
         /// </summary>
         /// <returns><see cref="AliasExpression"/> for use with any operation accepting a <see cref="AnyObjectElement"/>.</returns>
         /// <remarks>This version is required when creating aliases of any element that equates to a <see cref="String"/> type (<see cref="AnyStringElement"/> element).</remarks>
-        public static AliasExpression Alias(string alias)
+        public static AliasExpression<object?> Alias(string alias)
             => new(alias, typeof(object));
 
         /// <summary>

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/UnionTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/UnionTests.cs
@@ -450,6 +450,28 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
 
         [Theory]
         [MsSqlVersions.AllVersions]
+        public void Can_union_two_select_one_queries_successfully(int version, int personId = 1)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            IList<Person> persons = db.SelectOne<Person>()
+             .From(dbo.Person)
+             .Where(dbo.Person.Id == personId)
+             .UnionAll()
+             .SelectOne()
+             .From(dbo.Person)
+             .Where(dbo.Person.Id == personId)
+             .Execute();
+
+            //then
+            persons.Count().Should().Be(2);
+            persons.Should().Match(p => p.All(x => x.Id == personId));
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
         public void Can_union_two_enums_successfully(int version, int expected = 2)
         {
             //given

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/_Functions/_Interactions/CastAndLikeTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/_Functions/_Interactions/CastAndLikeTests.cs
@@ -10,11 +10,10 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
 {
     [Trait("Statement", "SELECT")]
     [Trait("Function", "CAST")]
-    [Trait("Function", "LIKE")]
+    [Trait("Operation", "LIKE")]
     public partial class CastAndLikeTests : ResetDatabaseNotRequired
     {
         [Theory]
-        [Trait("Operation", "LIKE")]
         [MsSqlVersions.AllVersions]
         public void Does_where_clause_using_cast_of_decimal_and_like_succeed(int version, int expected = 1)
         {
@@ -34,7 +33,6 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
         }
 
         [Theory]
-        [Trait("Operation", "LIKE")]
         [MsSqlVersions.AllVersions]
         public void Does_where_clause_using_cast_of_nullable_decimal_and_like_succeed(int version, int expected = 2)
         {

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/_SelectMany/_v2005/SelectManyTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/_SelectMany/_v2005/SelectManyTests.cs
@@ -20,7 +20,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
         public void Can_retrieve_page_of_purchase_records_using_cte_for_v2005(int version, int offset, int limit, bool prependCommanOnSelect, int expectedCount)
         {
             //given
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, c => c.SqlStatements.Assembly.ConfigureOutputSettings(o => o.PrependCommaOnSelectClause = prependCommanOnSelect));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, c => c.SqlStatements.Assembly.ConfigureAssemblyOptions(o => o.PrependCommaOnSelectClause = prependCommanOnSelect));
 
             var exp = db.SelectMany(dbo.Purchase.PersonId)
                 .From(dbo.Purchase)
@@ -45,7 +45,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
         public void Can_retrieve_page_of_purchase_records_using_distinct_and_cte_for_v2005(int version, int offset, int limit, bool prependCommanOnSelect, int expectedCount)
         {
             //given
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, c => c.SqlStatements.Assembly.ConfigureOutputSettings(o => o.PrependCommaOnSelectClause = prependCommanOnSelect));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, c => c.SqlStatements.Assembly.ConfigureAssemblyOptions(o => o.PrependCommaOnSelectClause = prependCommanOnSelect));
 
             var exp = db.SelectMany(dbo.Purchase.PersonId)
                 .Distinct()
@@ -67,7 +67,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
         public void Can_execute_trim_function_for_v2005(int version, bool prependCommanOnSelect, int expectedCount)
         {
             //given
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, c => c.SqlStatements.Assembly.ConfigureOutputSettings(o => o.PrependCommaOnSelectClause = prependCommanOnSelect));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, c => c.SqlStatements.Assembly.ConfigureAssemblyOptions(o => o.PrependCommaOnSelectClause = prependCommanOnSelect));
 
             //when
             IList<string> persons = db.SelectMany(db.fx.Trim(dbo.Person.FirstName))

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/Configuration/AssemblyContextConfigurationTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/Configuration/AssemblyContextConfigurationTests.cs
@@ -30,7 +30,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Configuration
         public void Does_configuration_for_appender_factory_using_null_configuration_action_throw_expected_exception(int version)
         {
             //given & when & then
-            Assert.Throws<DbExpressionConfigurationException>(() => Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.SqlStatements.Assembly.ConfigureOutputSettings(null!)));
+            Assert.Throws<DbExpressionConfigurationException>(() => Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.SqlStatements.Assembly.ConfigureAssemblyOptions(null!)));
         }
 
         [Theory]
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Configuration
         public void Does_configuration_for_appender_output_settings_with_configuration_action_succeed(int version)
         {
             //given
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.SqlStatements.Assembly.ConfigureOutputSettings(a => a.IdentifierDelimiter.Begin = '&'));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.SqlStatements.Assembly.ConfigureAssemblyOptions(a => a.IdentifierDelimiter.Begin = '&'));
 
             //when & then
             serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<AssemblyContext>().IdentifierDelimiter.Begin.Should().Be('&');
@@ -64,7 +64,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Configuration
         public void Assembly_context_with_custom_configuration_should_be_transient_when_resolved(int version)
         {
             //given
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.SqlStatements.Assembly.ConfigureOutputSettings(a => a.IdentifierDelimiter.Begin = '&'));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.SqlStatements.Assembly.ConfigureAssemblyOptions(a => a.IdentifierDelimiter.Begin = '&'));
 
             //when
             var a1 = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<AssemblyContext>();

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/Configuration/EntityMapperConfigurationTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/Configuration/EntityMapperConfigurationTests.cs
@@ -220,6 +220,88 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Configuration
             a1.Should().Be(a2);
         }
 
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_configuration_of_default_entity_mapping_factory_and_override_for_entity_type_using_instance_resolve_same_instance(int version)
+        {
+            //given
+            var impl = new EntityMapper<Person>((dbo.Person as Table<Person>).HydrateEntity);
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.Entities.Mapping.ForEntityTypes(c => c.ForEntityType<Person>().Use(impl)));
+            var factory = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IMapperFactory>();
+
+            //when
+            var a1 = factory.CreateEntityMapper<Person>(dbo.Person);
+
+            //then
+            a1.Should().Be(impl);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_configuration_of_default_entity_mapping_factory_and_override_for_entity_type_using_delegate_resolve_same_instance(int version)
+        {
+            //given
+            EntityMapper<Person>? impl = null;
+            Func<IEntityMapper<Person>> mapper = () => { impl = new EntityMapper<Person>((dbo.Person as Table<Person>).HydrateEntity); return impl; };
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.Entities.Mapping.ForEntityTypes(c => c.ForEntityType<Person>().Use(() => mapper())));
+            var factory = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IMapperFactory>();
+
+            //when
+            var a1 = factory.CreateEntityMapper<Person>(dbo.Person);
+
+            //then
+            a1.Should().Be(impl);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_configuration_of_default_entity_mapping_factory_and_override_for_entity_type_using_service_provider_resolve_same_instance(int version)
+        {
+            //given
+            EntityMapper<Person>? impl = null;
+            Func<IEntityMapper<Person>> mapper = () => { impl = new EntityMapper<Person>((dbo.Person as Table<Person>).HydrateEntity); return impl; };
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.Entities.Mapping.ForEntityTypes(c => c.ForEntityType<Person>().Use(sp => mapper())));
+            var factory = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IMapperFactory>();
+
+            //when
+            var a1 = factory.CreateEntityMapper<Person>(dbo.Person);
+
+            //then
+            a1.Should().Be(impl);
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_configuration_of_default_entity_mapping_factory_and_override_for_entity_type_using_generic_resolve_same_type(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.Entities.Mapping.ForEntityTypes(c => c.ForEntityType<Person>().Use<NoOpEntityMapper<Person>>()));
+            var factory = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IMapperFactory>();
+
+            //when
+            var a1 = factory.CreateEntityMapper<Person>(dbo.Person);
+
+            //then
+            a1.Should().BeOfType<NoOpEntityMapper<Person>>();
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Does_configuration_of_default_entity_mapping_factory_and_override_for_entity_type_using_delegate_for_reader_map_correctly(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.Entities.Mapping.ForEntityTypes(c => c.ForEntityType<Person>().Use((reader, person) => person.FirstName = "Bob")));
+            var factory = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IMapperFactory>();
+            var a1 = factory.CreateEntityMapper<Person>(dbo.Person);
+            var person = new Person() { FirstName = "Mary" };
+
+            //when
+            a1.Map((ISqlFieldReader)null!, person);
+
+            //then
+            person.FirstName.Should().Be("Bob");
+        }
+
         public class NoOpEntityMapper<TEntity> : IEntityMapper<TEntity>
             where TEntity : class, IDbEntity, new()
         {

--- a/test/HatTrick.DbEx.MsSql.Test/DatabaseConfigurationBuilder{T}.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/DatabaseConfigurationBuilder{T}.cs
@@ -26,7 +26,7 @@ namespace HatTrick.DbEx.MsSql.Test
 
                 database.ConnectionString.Use(connectionString);
 
-                database.SqlStatements.Assembly.ConfigureOutputSettings(
+                database.SqlStatements.Assembly.ConfigureAssemblyOptions(
                     x => x.PrependCommaOnSelectClause = false
                 );
 


### PR DESCRIPTION
- Changed configuration syntax:
	- .ConfigureOutputSettings -> .ConfigureAssemblyOptions
	- .ConfigureLoggingSettings -> .ConfigureLoggingOptions
- Added additional configuration options for entity factories
- Added additional configuration options for entity mappers
- Changed return type of Alias operation to be consistent with other method