### PR TITLE
- Fixed async event tests that intermittently fail

### DIFF
--- a/benchmark/Benchmark.MsSql/Benchmark.MsSql.csproj
+++ b/benchmark/Benchmark.MsSql/Benchmark.MsSql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>disable</Nullable>
@@ -30,6 +30,7 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/benchmark/Benchmark.MsSql/BenchmarkSqlStatementExecutor.cs
+++ b/benchmark/Benchmark.MsSql/BenchmarkSqlStatementExecutor.cs
@@ -1,4 +1,6 @@
 ﻿using HatTrick.DbEx.MsSql.Benchmark.dbExpression.DataService;
+using HatTrick.DbEx.MsSql.Benchmark.dbExpression.dboData;
+using HatTrick.DbEx.MsSql.Benchmark.dbExpression.dboDataService;
 using HatTrick.DbEx.Sql;
 using HatTrick.DbEx.Sql.Connection;
 using HatTrick.DbEx.Sql.Converter;
@@ -19,8 +21,8 @@ namespace HatTrick.DbEx.MsSql.Benchmark
         private static ISqlRowReader _reader;
         private static IAsyncSqlRowReader _asyncReader;
 
-        private IAsyncSqlRowReader asyncReader => _asyncReader ?? (_asyncReader = new PersonRowReader(new SqlStatementValueConverterProvider(provider.GetRequiredService<IValueConverterFactory>())));
-        private ISqlRowReader reader => _reader ?? (_reader = new PersonRowReader(new SqlStatementValueConverterProvider(provider.GetRequiredService<IValueConverterFactory>())));
+        private IAsyncSqlRowReader asyncReader => _asyncReader ?? (_asyncReader = new PersonRowReader(new SqlStatementValueConverterProvider(provider.GetRequiredService<IValueConverterFactory>(), (dbo.Person as Table<Person>).BuildInclusiveSelectExpression())));
+        private ISqlRowReader reader => _reader ?? (_reader = new PersonRowReader(new SqlStatementValueConverterProvider(provider.GetRequiredService<IValueConverterFactory>(), (dbo.Person as Table<Person>).BuildInclusiveSelectExpression())));
 
         public BenchmarkSqlStatementExecutor(IServiceProvider provider)
         {

--- a/benchmark/Benchmark.MsSql/Config.cs
+++ b/benchmark/Benchmark.MsSql/Config.cs
@@ -44,7 +44,7 @@ namespace HatTrick.DbEx.MsSql.Benchmark
                    .WithUnrollFactor(Iterations)
                    .WithIterationCount(10)
             );
-            Orderer = new DefaultOrderer(SummaryOrderPolicy.FastestToSlowest);
+            Orderer = new DefaultOrderer(SummaryOrderPolicy.Method);
             Options |= ConfigOptions.JoinSummary;
         }
     }

--- a/benchmark/Benchmark.MsSql/MapperBenchmarks.cs
+++ b/benchmark/Benchmark.MsSql/MapperBenchmarks.cs
@@ -32,7 +32,7 @@ namespace HatTrick.DbEx.MsSql.Benchmark
             services.AddDbExpression(dbex => dbex.AddDatabase<BenchmarkDatabase>(c => c.ConnectionString.Use(connectionString)));
             var serviceProvider = services.BuildServiceProvider();
 
-            valueConverterProvider = new SqlStatementValueConverterProvider(serviceProvider.GetRequiredService<IValueConverterFactory>());
+            valueConverterProvider = new SqlStatementValueConverterProvider(serviceProvider.GetRequiredService<IValueConverterFactory>(), (dbo.Person as Table<Person>).BuildInclusiveSelectExpression());
             personMapper = serviceProvider.GetRequiredService<IMapperFactory>().CreateEntityMapper(dbo.Person);
             personObjectMapper = serviceProvider.GetRequiredService<IMapperFactory>().CreateExpandoObjectMapper();
         }

--- a/benchmark/Benchmark.MsSql/PersonFieldReader.cs
+++ b/benchmark/Benchmark.MsSql/PersonFieldReader.cs
@@ -1,6 +1,7 @@
 ﻿using HatTrick.DbEx.MsSql.Benchmark.dbExpression.dboData;
 using HatTrick.DbEx.MsSql.Benchmark.dbExpression.dboDataService;
 using HatTrick.DbEx.Sql;
+using HatTrick.DbEx.Sql.Converter;
 using HatTrick.DbEx.Sql.Executor;
 using System;
 using System.Collections.Generic;
@@ -58,19 +59,31 @@ namespace HatTrick.DbEx.MsSql.Benchmark
             if (fieldReader is not null)
                 return null; //ensure this method returns only 1 row when invoked
 
-            fieldReader = new Row(0, new ISqlField[11]
+            int zero = 0;
+            int one = 1;
+            int two = 2;
+            int three = 3;
+            int four = 4;
+            int five = 5;
+            int six = 6;
+            int seven = 7;
+            int eight = 8;
+            int nine = 9;
+            int ten = 10;
+
+            fieldReader = new Row(ref zero, new ISqlField[11]
                 {
-                    new Field(0, nameof(dbo.Person.Id), typeof(int), person.Id, (f, t) => valueConverterProvider.FindConverter(0, t, f.RawValue)),
-                    new Field(1, nameof(dbo.Person.FirstName), typeof(string), person.FirstName, (f, t) => valueConverterProvider.FindConverter(1, t, person.FirstName)),
-                    new Field(2, nameof(dbo.Person.LastName), typeof(string), person.LastName, (f, t) => valueConverterProvider.FindConverter(2, t, person.LastName)),
-                    new Field(3, nameof(dbo.Person.BirthDate), typeof(DateTime?), person.BirthDate, (f, t) => valueConverterProvider.FindConverter(3, t, person.BirthDate)),
-                    new Field(4, nameof(dbo.Person.GenderType), typeof(GenderType), person.GenderType, (f, t) => valueConverterProvider.FindConverter(4, t, person.GenderType)),
-                    new Field(5, nameof(dbo.Person.CreditLimit), typeof(int?), person.CreditLimit, (f, t) => valueConverterProvider.FindConverter(5, t, person.CreditLimit)),
-                    new Field(6, nameof(dbo.Person.YearOfLastCreditLimitReview), typeof(int?), person.YearOfLastCreditLimitReview, (f, t) => valueConverterProvider.FindConverter(6, t, person.YearOfLastCreditLimitReview)),
-                    new Field(7, nameof(dbo.Person.RegistrationDate), typeof(DateTimeOffset), person.RegistrationDate, (f, t) => valueConverterProvider.FindConverter(7, t, person.RegistrationDate)),
-                    new Field(8, nameof(dbo.Person.LastLoginDate), typeof(DateTimeOffset?), person.LastLoginDate, (f, t) => valueConverterProvider.FindConverter(8, t, person.LastLoginDate)),
-                    new Field(9, nameof(dbo.Person.DateCreated), typeof(DateTime), person.DateCreated, (f, t) => valueConverterProvider.FindConverter(9, t, person.DateCreated)),
-                    new Field(10, nameof(dbo.Person.DateUpdated), typeof(DateTime), person.DateUpdated, (f, t) => valueConverterProvider.FindConverter(10, t, person.DateUpdated)),
+                    new Field(ref zero, nameof(dbo.Person.Id), typeof(int), person.Id, valueConverterProvider),
+                    new Field(ref one, nameof(dbo.Person.FirstName), typeof(string), person.FirstName, valueConverterProvider),
+                    new Field(ref two, nameof(dbo.Person.LastName), typeof(string), person.LastName, valueConverterProvider),
+                    new Field(ref three, nameof(dbo.Person.BirthDate), typeof(DateTime?), person.BirthDate, valueConverterProvider),
+                    new Field(ref four, nameof(dbo.Person.GenderType), typeof(GenderType), person.GenderType, valueConverterProvider),
+                    new Field(ref five, nameof(dbo.Person.CreditLimit), typeof(int?), person.CreditLimit, valueConverterProvider),
+                    new Field(ref six, nameof(dbo.Person.YearOfLastCreditLimitReview), typeof(int?), person.YearOfLastCreditLimitReview,valueConverterProvider),
+                    new Field(ref seven, nameof(dbo.Person.RegistrationDate), typeof(DateTimeOffset), person.RegistrationDate, valueConverterProvider),
+                    new Field(ref eight, nameof(dbo.Person.LastLoginDate), typeof(DateTimeOffset?), person.LastLoginDate, valueConverterProvider),
+                    new Field(ref nine, nameof(dbo.Person.DateCreated), typeof(DateTime), person.DateCreated, valueConverterProvider),
+                    new Field(ref ten, nameof(dbo.Person.DateUpdated), typeof(DateTime), person.DateUpdated, valueConverterProvider),
                 });
             return fieldReader;
         }

--- a/benchmark/Benchmark.MsSql/Program.cs
+++ b/benchmark/Benchmark.MsSql/Program.cs
@@ -3,6 +3,7 @@ using HatTrick.DbEx.MsSql.Benchmark;
 using System.Linq;
 
 //BenchmarkRunner.Run<QueryExpressionBenchmarks>();
+//BenchmarkRunner.Run<QueryExecutionBenchmarks>();
 //BenchmarkRunner.Run<SqlStatementAssemblyBenchmarks>();
 //BenchmarkRunner.Run<MapperBenchmarks>();
 

--- a/benchmark/Benchmark.MsSql/QueryExecutionBenchmarks.cs
+++ b/benchmark/Benchmark.MsSql/QueryExecutionBenchmarks.cs
@@ -1,0 +1,98 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using HatTrick.DbEx.MsSql.Benchmark.dbExpression.DataService;
+using HatTrick.DbEx.MsSql.Benchmark.dbExpression.dboData;
+using HatTrick.DbEx.MsSql.Benchmark.dbExpression.dboDataService;
+using HatTrick.DbEx.MsSql.Configuration;
+using HatTrick.DbEx.Sql;
+using HatTrick.DbEx.Sql.Connection;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+
+namespace HatTrick.DbEx.MsSql.Benchmark
+{
+    [MemoryDiagnoser]
+    [Orderer(SummaryOrderPolicy.FastestToSlowest)]
+    [RankColumn]
+    public class QueryExecutionBenchmarks
+    {
+        private const string connectionString = "Data Source=(LocalDB)\\MSSQLLocalDB;Initial Catalog=MsSqlDbExTest;Integrated Security=true;";
+        private ISqlConnection _connection;
+
+        [GlobalSetup]
+        public void ConfigureDbExpression()
+        {
+            var services = new ServiceCollection();
+            services.AddDbExpression(dbex => dbex.AddDatabase<BenchmarkDatabase>(c => c.ConnectionString.Use(connectionString)));
+            var serviceProvider = services.BuildServiceProvider();
+            serviceProvider.UseStaticRuntimeFor<BenchmarkDatabase>();
+
+            _connection = db.GetConnection();
+        }
+
+        [Benchmark]
+        public void ExecuteSelectQueryExpression()
+        {
+            db.SelectMany<Person>().From(dbo.Person).Execute(_connection).ToList();
+        }
+
+        [Benchmark]
+        public void ExecuteSelectQueryExpressionWithFieldAlias()
+        {
+            db.SelectMany(
+                dbo.Person.Id.As("person_Id"),
+                dbo.Person.FirstName.As("person_FirstName"),
+                dbo.Person.LastName.As("person_LastName")
+            )
+            .From(dbo.Person)
+            .Execute(_connection).ToList();
+        }
+
+        [Benchmark]
+        public void ExecuteSelectQueryExpressionWithJoinClause()
+        {
+            db.SelectMany<Person>()
+            .From(dbo.Person)
+            .InnerJoin(dbo.PersonAddress).On(dbo.Person.Id == dbo.PersonAddress.PersonId)
+            .Execute(_connection).ToList();
+        }
+
+        [Benchmark]
+        public void ExecuteSelectQueryExpressionWithWhereClause()
+        {
+            db.SelectMany<Person>()
+            .From(dbo.Person)
+            .Where(dbo.Person.FirstName.Like("b%") & dbo.Person.CreditLimit > 1)
+            .Execute(_connection).ToList();
+        }
+
+        [Benchmark]
+        public void ExecuteSelectQueryExpressionWithOrderByClause()
+        {
+            db.SelectMany<Person>()
+            .From(dbo.Person)
+            .OrderBy(dbo.Person.FirstName, dbo.Person.CreditLimit)
+            .Execute(_connection).ToList();
+        }
+
+        [Benchmark]
+        public void ExecuteSelectQueryExpressionWithCountFunctionAndGroupByClause()
+        {
+            db.SelectMany(db.fx.Count())
+            .From(dbo.Person)
+            .GroupBy(dbo.Person.FirstName)
+            .Execute(_connection).ToList();
+        }
+
+        [Benchmark]
+        public void ExecuteSelectQueryExpressionWithCountFunctionAndGroupByClauseAndHavingClause()
+        {
+            db.SelectMany(db.fx.Count())
+            .From(dbo.Person)
+            .GroupBy(dbo.Person.FirstName)
+            .Having(db.fx.Count() > 1)
+            .Execute(_connection).ToList();
+        }
+    }
+}

--- a/benchmark/Benchmark.MsSql/dbExpression/_dbExpression.Generated/DbExDataService.generated.cs
+++ b/benchmark/Benchmark.MsSql/dbExpression/_dbExpression.Generated/DbExDataService.generated.cs
@@ -1134,7 +1134,7 @@ namespace HatTrick.DbEx.MsSql.Benchmark.dbExpression.DataService
         private static readonly SqlDatabaseMetadataProvider _metadata = new SqlDatabaseMetadataProvider(new BenchmarkDatabaseSqlDatabaseMetadata("BenchmarkDatabase"));
         private static readonly MsSqlFunctionExpressionBuilder _fx = new MsSqlFunctionExpressionBuilder();
         private static readonly List<SchemaExpression> _schemas = new List<SchemaExpression>();
-        private static readonly Dictionary<Type, Table> _entityTypeToTableMap = new Dictionary<Type, Table>();
+        private static readonly Dictionary<EntityTypeKey, Table> _entityTypeToTableMap = new Dictionary<EntityTypeKey, Table>();
         private readonly IQueryExpressionBuilderFactory<BenchmarkDatabase> _queryExpressionBuilderFactory;
         private readonly IDbConnectionFactory _connectionFactory;
         private BenchmarkDatabaseStoredProcedures? _sp;
@@ -1153,19 +1153,19 @@ namespace HatTrick.DbEx.MsSql.Benchmark.dbExpression.DataService
             var dboSchema = new _dboDataService.dboSchemaExpression(1);
             _schemas.Add(dboSchema);
             _dboDataService.dbo.UseSchema(dboSchema);
-            _entityTypeToTableMap.Add(typeof(dboData.AccessAuditLog), dboSchema.AccessAuditLog);
-            _entityTypeToTableMap.Add(typeof(dboData.Address), dboSchema.Address);
-            _entityTypeToTableMap.Add(typeof(dboData.Person), dboSchema.Person);
-            _entityTypeToTableMap.Add(typeof(dboData.PersonAddress), dboSchema.PersonAddress);
-            _entityTypeToTableMap.Add(typeof(dboData.Product), dboSchema.Product);
-            _entityTypeToTableMap.Add(typeof(dboData.Purchase), dboSchema.Purchase);
-            _entityTypeToTableMap.Add(typeof(dboData.PurchaseLine), dboSchema.PurchaseLine);
-            _entityTypeToTableMap.Add(typeof(dboData.PersonTotalPurchasesView), dboSchema.PersonTotalPurchasesView);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.AccessAuditLog).TypeHandle.Value), dboSchema.AccessAuditLog);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Address).TypeHandle.Value), dboSchema.Address);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Person).TypeHandle.Value), dboSchema.Person);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.PersonAddress).TypeHandle.Value), dboSchema.PersonAddress);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Product).TypeHandle.Value), dboSchema.Product);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Purchase).TypeHandle.Value), dboSchema.Purchase);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.PurchaseLine).TypeHandle.Value), dboSchema.PurchaseLine);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.PersonTotalPurchasesView).TypeHandle.Value), dboSchema.PersonTotalPurchasesView);
 
             var secSchema = new _secDataService.secSchemaExpression(114);
             _schemas.Add(secSchema);
             _secDataService.sec.UseSchema(secSchema);
-            _entityTypeToTableMap.Add(typeof(secData.Person), secSchema.Person);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(secData.Person).TypeHandle.Value), secSchema.Person);
 
         }
 
@@ -2253,9 +2253,9 @@ namespace HatTrick.DbEx.MsSql.Benchmark.dbExpression.DataService
         protected virtual Table<TEntity> GetTable<TEntity>()
             where TEntity : class, IDbEntity
         {
-            if (!_entityTypeToTableMap.ContainsKey(typeof(TEntity)))
+            if (!_entityTypeToTableMap.TryGetValue(new EntityTypeKey(typeof(TEntity).TypeHandle.Value), out var table))
                 throw new DbExpressionException($"Entity type {typeof(TEntity)} is not known.");
-            return _entityTypeToTableMap[typeof(TEntity)] as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {typeof(TEntity)}.");
+            return table as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {typeof(TEntity)}.");
         }
         #endregion
 
@@ -2649,6 +2649,17 @@ namespace HatTrick.DbEx.MsSql.Benchmark.dbExpression.DataService
         }
 
         #endregion
+        #endregion
+
+        #region classes
+        private readonly struct EntityTypeKey : IEquatable<EntityTypeKey>
+        {
+            public readonly IntPtr Ptr;
+            public EntityTypeKey(IntPtr key) => Ptr = key;
+            public bool Equals(EntityTypeKey other) => Ptr == other.Ptr;
+            public override int GetHashCode() => Ptr.GetHashCode();
+            public override bool Equals(object? obj) => obj is EntityTypeKey other && Equals(other);
+        }
         #endregion
     }
     #endregion

--- a/benchmark/Benchmark.MsSql/dbExpression/dbExpressionBenchmarks.cs
+++ b/benchmark/Benchmark.MsSql/dbExpression/dbExpressionBenchmarks.cs
@@ -5,8 +5,11 @@ using HatTrick.DbEx.MsSql.Benchmark.dbExpression.dboData;
 using HatTrick.DbEx.MsSql.Benchmark.dbExpression.dboDataService;
 using HatTrick.DbEx.MsSql.Configuration;
 using HatTrick.DbEx.Sql;
+using HatTrick.DbEx.Sql.Assembler;
 using HatTrick.DbEx.Sql.Connection;
+using HatTrick.DbEx.Sql.Mapper;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace HatTrick.DbEx.MsSql.Benchmark
@@ -27,8 +30,11 @@ namespace HatTrick.DbEx.MsSql.Benchmark
                 dbex.AddDatabase<BenchmarkDatabase>(database => database.ConnectionString.Use(Constants.ConnectionString));
             });
             var provider = services.BuildServiceProvider();
-            provider.UseStaticRuntimeFor<BenchmarkDatabase>(); 
-            
+            provider.UseStaticRuntimeFor<BenchmarkDatabase>();
+
+			//"pre-fetch" an entity so first creation isn't measured
+            provider.GetServiceProviderFor<BenchmarkDatabase>().GetRequiredService<IEntityFactory>().CreateEntity<Person>();
+
             connection = db.GetConnection();
             connection.EnsureOpen();
         }
@@ -58,7 +64,7 @@ namespace HatTrick.DbEx.MsSql.Benchmark
         }
 
         [Benchmark(Description = "Select First Record With Dynamic Return")]
-        public dynamic SelectOneDynamicQueryExpression()
+        public dynamic SelectOneDynamicQueryExpressionBaseline()
         {
             return db.SelectOne(dbo.Person.Id, dbo.Person.FirstName, dbo.Person.LastName).From(dbo.Person).Execute(connection);
         }

--- a/benchmark/Profiling.MsSql/Generated/DbExDataService.generated.cs
+++ b/benchmark/Profiling.MsSql/Generated/DbExDataService.generated.cs
@@ -1134,7 +1134,7 @@ namespace Profiling.MsSql.DataService
         private static readonly SqlDatabaseMetadataProvider _metadata = new SqlDatabaseMetadataProvider(new ProfilingDatabaseSqlDatabaseMetadata("ProfilingDatabase"));
         private static readonly MsSqlFunctionExpressionBuilder _fx = new MsSqlFunctionExpressionBuilder();
         private static readonly List<SchemaExpression> _schemas = new List<SchemaExpression>();
-        private static readonly Dictionary<Type, Table> _entityTypeToTableMap = new Dictionary<Type, Table>();
+        private static readonly Dictionary<EntityTypeKey, Table> _entityTypeToTableMap = new Dictionary<EntityTypeKey, Table>();
         private readonly IQueryExpressionBuilderFactory<ProfilingDatabase> _queryExpressionBuilderFactory;
         private readonly IDbConnectionFactory _connectionFactory;
         private ProfilingDatabaseStoredProcedures? _sp;
@@ -1153,19 +1153,19 @@ namespace Profiling.MsSql.DataService
             var dboSchema = new _dboDataService.dboSchemaExpression(1);
             _schemas.Add(dboSchema);
             _dboDataService.dbo.UseSchema(dboSchema);
-            _entityTypeToTableMap.Add(typeof(dboData.AccessAuditLog), dboSchema.AccessAuditLog);
-            _entityTypeToTableMap.Add(typeof(dboData.Address), dboSchema.Address);
-            _entityTypeToTableMap.Add(typeof(dboData.Person), dboSchema.Person);
-            _entityTypeToTableMap.Add(typeof(dboData.PersonAddress), dboSchema.PersonAddress);
-            _entityTypeToTableMap.Add(typeof(dboData.Product), dboSchema.Product);
-            _entityTypeToTableMap.Add(typeof(dboData.Purchase), dboSchema.Purchase);
-            _entityTypeToTableMap.Add(typeof(dboData.PurchaseLine), dboSchema.PurchaseLine);
-            _entityTypeToTableMap.Add(typeof(dboData.PersonTotalPurchasesView), dboSchema.PersonTotalPurchasesView);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.AccessAuditLog).TypeHandle.Value), dboSchema.AccessAuditLog);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Address).TypeHandle.Value), dboSchema.Address);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Person).TypeHandle.Value), dboSchema.Person);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.PersonAddress).TypeHandle.Value), dboSchema.PersonAddress);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Product).TypeHandle.Value), dboSchema.Product);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Purchase).TypeHandle.Value), dboSchema.Purchase);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.PurchaseLine).TypeHandle.Value), dboSchema.PurchaseLine);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.PersonTotalPurchasesView).TypeHandle.Value), dboSchema.PersonTotalPurchasesView);
 
             var secSchema = new _secDataService.secSchemaExpression(114);
             _schemas.Add(secSchema);
             _secDataService.sec.UseSchema(secSchema);
-            _entityTypeToTableMap.Add(typeof(secData.Person), secSchema.Person);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(secData.Person).TypeHandle.Value), secSchema.Person);
 
         }
 
@@ -2253,9 +2253,9 @@ namespace Profiling.MsSql.DataService
         protected virtual Table<TEntity> GetTable<TEntity>()
             where TEntity : class, IDbEntity
         {
-            if (!_entityTypeToTableMap.ContainsKey(typeof(TEntity)))
+            if (!_entityTypeToTableMap.TryGetValue(new EntityTypeKey(typeof(TEntity).TypeHandle.Value), out var table))
                 throw new DbExpressionException($"Entity type {typeof(TEntity)} is not known.");
-            return _entityTypeToTableMap[typeof(TEntity)] as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {typeof(TEntity)}.");
+            return table as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {typeof(TEntity)}.");
         }
         #endregion
 
@@ -2649,6 +2649,17 @@ namespace Profiling.MsSql.DataService
         }
 
         #endregion
+        #endregion
+
+        #region classes
+        private readonly struct EntityTypeKey : IEquatable<EntityTypeKey>
+        {
+            public readonly IntPtr Ptr;
+            public EntityTypeKey(IntPtr key) => Ptr = key;
+            public bool Equals(EntityTypeKey other) => Ptr == other.Ptr;
+            public override int GetHashCode() => Ptr.GetHashCode();
+            public override bool Equals(object? obj) => obj is EntityTypeKey other && Equals(other);
+        }
         #endregion
     }
     #endregion

--- a/benchmark/Profiling.MsSql/Profiling.MsSql.csproj
+++ b/benchmark/Profiling.MsSql/Profiling.MsSql.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net7.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -15,6 +15,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/benchmark/Profiling.MsSql/Program.cs
+++ b/benchmark/Profiling.MsSql/Program.cs
@@ -1,5 +1,6 @@
 ﻿using HatTrick.DbEx.MsSql.Configuration;
 using HatTrick.DbEx.Sql;
+using HatTrick.DbEx.Sql.Assembler;
 using JetBrains.Profiler.Api;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,7 +19,11 @@ using IProfileTarget sut = new SelectOneQueryExpressionProfileTarget();
 var services = new ServiceCollection();
 services.AddDbExpression(dbex =>
 {
-    dbex.AddDatabase<ProfilingDatabase>(db => { db.ConnectionString.Use(connectionString); sut.Configure(db); });
+    dbex.AddDatabase<ProfilingDatabase>(database =>
+    {
+        database.ConnectionString.Use(connectionString);
+        sut.Configure(database);
+    });
 });
 var provider = services.BuildServiceProvider();
 provider.UseStaticRuntimeFor<ProfilingDatabase>();

--- a/benchmark/Profiling.MsSql/Target/_AssembleQuery/AppendFieldExpressionProfileTarget.cs
+++ b/benchmark/Profiling.MsSql/Target/_AssembleQuery/AppendFieldExpressionProfileTarget.cs
@@ -1,19 +1,12 @@
 ﻿using HatTrick.DbEx.Sql.Assembler;
-using HatTrick.DbEx.Sql.Configuration;
 using HatTrick.DbEx.Sql.Expression;
 using Microsoft.Extensions.DependencyInjection;
-using Profiling.MsSql.DataService;
 using Profiling.MsSql.dboDataService;
 
 namespace Profiling.MsSql.Target
 {
     public class AppendFieldExpressionProfileTarget : AssembleQueryProfileTarget
     {
-        public override void Configure(ISqlDatabaseRuntimeConfigurationBuilder<ProfilingDatabase> configure)
-        {
-
-        }
-
         public override void Execute(IServiceProvider provider)
         {
             var builder = provider.GetRequiredService<ISqlStatementBuilder>();

--- a/benchmark/Profiling.MsSql/Target/_AssembleQuery/AssembleQueryProfileTarget.cs
+++ b/benchmark/Profiling.MsSql/Target/_AssembleQuery/AssembleQueryProfileTarget.cs
@@ -1,5 +1,7 @@
 ﻿using Profiling.MsSql.DataService;
 using HatTrick.DbEx.Sql.Configuration;
+using System.Buffers;
+using HatTrick.DbEx.Sql.Assembler;
 
 namespace Profiling.MsSql.Target
 {

--- a/benchmark/Profiling.MsSql/Target/_AssembleQuery/AssembleStatementProfileTarget.cs
+++ b/benchmark/Profiling.MsSql/Target/_AssembleQuery/AssembleStatementProfileTarget.cs
@@ -1,0 +1,20 @@
+﻿using HatTrick.DbEx.MsSql.Configuration;
+using HatTrick.DbEx.Sql.Assembler;
+using HatTrick.DbEx.Sql.Expression;
+using Microsoft.Extensions.DependencyInjection;
+using Profiling.MsSql.DataService;
+using Profiling.MsSql.dboData;
+using Profiling.MsSql.dboDataService;
+
+namespace Profiling.MsSql.Target
+{
+    public class AssembleStatementProfileTarget : AssembleQueryProfileTarget
+    {
+        private static readonly QueryExpression selectQueryExpression = (db.SelectMany<Person>().From(dbo.Person).InnerJoin(dbo.PersonAddress).On(dbo.Person.Id == dbo.PersonAddress.PersonId).InnerJoin(dbo.Address).On(dbo.Address.Id == dbo.PersonAddress.AddressId)).Expression;
+
+        public override void Execute(IServiceProvider serviceProvider)
+        {
+            serviceProvider.GetServiceProviderFor<ProfilingDatabase>().GetRequiredService<ISqlStatementBuilder>().CreateSqlStatement(selectQueryExpression);
+        }
+    }
+}

--- a/benchmark/Profiling.MsSql/Target/_ExecuteQuery/SelectManyQueryExpressionProfileTarget.cs
+++ b/benchmark/Profiling.MsSql/Target/_ExecuteQuery/SelectManyQueryExpressionProfileTarget.cs
@@ -1,0 +1,14 @@
+﻿using Profiling.MsSql.DataService;
+using Profiling.MsSql.dboData;
+using Profiling.MsSql.dboDataService;
+
+namespace Profiling.MsSql.Target
+{
+    public class SelectManyQueryExpressionProfileTarget : ExecuteQueryProfileTarget
+    {
+        public override void Execute(IServiceProvider provider)
+        {
+            db.SelectMany<Person>().From(dbo.Person).Execute(Connection.Value).ToList();
+        }
+    }
+}

--- a/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
+++ b/samples/mssql/ServerSideBlazorApp/Data/_Generated/DbExDataService.generated.cs
@@ -1134,7 +1134,7 @@ namespace ServerSideBlazorApp.DataService
         private static readonly SqlDatabaseMetadataProvider _metadata = new SqlDatabaseMetadataProvider(new CRMDatabaseSqlDatabaseMetadata("CRMDatabase"));
         private static readonly MsSqlFunctionExpressionBuilder _fx = new MsSqlFunctionExpressionBuilder();
         private static readonly List<SchemaExpression> _schemas = new List<SchemaExpression>();
-        private static readonly Dictionary<Type, Table> _entityTypeToTableMap = new Dictionary<Type, Table>();
+        private static readonly Dictionary<EntityTypeKey, Table> _entityTypeToTableMap = new Dictionary<EntityTypeKey, Table>();
         private readonly IQueryExpressionBuilderFactory<CRMDatabase> _queryExpressionBuilderFactory;
         private readonly IDbConnectionFactory _connectionFactory;
         private CRMDatabaseStoredProcedures? _sp;
@@ -1153,18 +1153,18 @@ namespace ServerSideBlazorApp.DataService
             var dboSchema = new _dboDataService.dboSchemaExpression(1);
             _schemas.Add(dboSchema);
             _dboDataService.dbo.UseSchema(dboSchema);
-            _entityTypeToTableMap.Add(typeof(dboData.Address), dboSchema.Address);
-            _entityTypeToTableMap.Add(typeof(dboData.Customer), dboSchema.Customer);
-            _entityTypeToTableMap.Add(typeof(dboData.CustomerAddress), dboSchema.CustomerAddress);
-            _entityTypeToTableMap.Add(typeof(dboData.Product), dboSchema.Product);
-            _entityTypeToTableMap.Add(typeof(dboData.Purchase), dboSchema.Purchase);
-            _entityTypeToTableMap.Add(typeof(dboData.PurchaseLine), dboSchema.PurchaseLine);
-            _entityTypeToTableMap.Add(typeof(dboData.PersonTotalPurchasesView), dboSchema.PersonTotalPurchasesView);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Address).TypeHandle.Value), dboSchema.Address);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Customer).TypeHandle.Value), dboSchema.Customer);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.CustomerAddress).TypeHandle.Value), dboSchema.CustomerAddress);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Product).TypeHandle.Value), dboSchema.Product);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Purchase).TypeHandle.Value), dboSchema.Purchase);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.PurchaseLine).TypeHandle.Value), dboSchema.PurchaseLine);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.PersonTotalPurchasesView).TypeHandle.Value), dboSchema.PersonTotalPurchasesView);
 
             var secSchema = new _secDataService.secSchemaExpression(110);
             _schemas.Add(secSchema);
             _secDataService.sec.UseSchema(secSchema);
-            _entityTypeToTableMap.Add(typeof(secData.Person), secSchema.Person);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(secData.Person).TypeHandle.Value), secSchema.Person);
 
         }
 
@@ -2252,9 +2252,9 @@ namespace ServerSideBlazorApp.DataService
         protected virtual Table<TEntity> GetTable<TEntity>()
             where TEntity : class, IDbEntity
         {
-            if (!_entityTypeToTableMap.ContainsKey(typeof(TEntity)))
+            if (!_entityTypeToTableMap.TryGetValue(new EntityTypeKey(typeof(TEntity).TypeHandle.Value), out var table))
                 throw new DbExpressionException($"Entity type {typeof(TEntity)} is not known.");
-            return _entityTypeToTableMap[typeof(TEntity)] as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {typeof(TEntity)}.");
+            return table as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {typeof(TEntity)}.");
         }
         #endregion
 
@@ -2667,6 +2667,17 @@ namespace ServerSideBlazorApp.DataService
         }
 
         #endregion
+        #endregion
+
+        #region classes
+        private readonly struct EntityTypeKey : IEquatable<EntityTypeKey>
+        {
+            public readonly IntPtr Ptr;
+            public EntityTypeKey(IntPtr key) => Ptr = key;
+            public bool Equals(EntityTypeKey other) => Ptr == other.Ptr;
+            public override int GetHashCode() => Ptr.GetHashCode();
+            public override bool Equals(object? obj) => obj is EntityTypeKey other && Equals(other);
+        }
         #endregion
     }
     #endregion

--- a/src/HatTrick.DbEx.MsSql/Types/MsSqlTypeMapFactory.cs
+++ b/src/HatTrick.DbEx.MsSql/Types/MsSqlTypeMapFactory.cs
@@ -32,7 +32,7 @@ namespace HatTrick.DbEx.MsSql.Types
         /// reference: https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/sql-server-data-type-mappings
         /// </summary>
         /// <remarks>Precedence in this last is important; when resolving a SqlDbType or DbType by .NET runtime type, the "first" in the list matching the .NET runtime type will be returned.</remarks>
-        private static readonly List<DbTypeMap<SqlDbType>> typeMaps = new List<DbTypeMap<SqlDbType>>()
+        private static readonly List<DbTypeMap<SqlDbType>> typeMaps = new()
         {
             new DbTypeMap<SqlDbType>(typeof(long), DbType.Int64, SqlDbType.BigInt),
             new DbTypeMap<SqlDbType>(typeof(long?), DbType.Int64, SqlDbType.BigInt),
@@ -50,7 +50,7 @@ namespace HatTrick.DbEx.MsSql.Types
 
             //new DbTypeMap<SqlDbType>(typeof(char), DbType.AnsiStringFixedLength, SqlDbType.Char),
             //new DbTypeMap<SqlDbType>(typeof(char?), DbType.AnsiStringFixedLength, SqlDbType.Char),
-            new DbTypeMap<SqlDbType>(typeof(string), DbType.AnsiStringFixedLength, SqlDbType.Char), //dbExpression doesn't support Char expressions; they map to string
+            //new DbTypeMap<SqlDbType>(typeof(string), DbType.AnsiStringFixedLength, SqlDbType.Char), //dbExpression doesn't support Char expressions; they map to string
             new DbTypeMap<SqlDbType>(typeof(char), DbType.StringFixedLength, SqlDbType.NChar),
             new DbTypeMap<SqlDbType>(typeof(char?), DbType.StringFixedLength, SqlDbType.NChar),
             new DbTypeMap<SqlDbType>(typeof(string), DbType.AnsiString, SqlDbType.VarChar),
@@ -99,6 +99,19 @@ namespace HatTrick.DbEx.MsSql.Types
             new DbTypeMap<SqlDbType>(typeof(float), DbType.Single, SqlDbType.Real),
             new DbTypeMap<SqlDbType>(typeof(float?), DbType.Single, SqlDbType.Real)
         };
+
+        private static readonly HashSet<DbType> unicodeDbTypes = new()
+        {
+            DbType.StringFixedLength,
+            DbType.String
+        };
+
+        private static readonly HashSet<SqlDbType> unicodePlatformTypes = new()
+        {
+            SqlDbType.NChar,
+            SqlDbType.NText,
+            SqlDbType.NVarChar
+        };
         #endregion
 
         #region methods
@@ -111,7 +124,7 @@ namespace HatTrick.DbEx.MsSql.Types
         public DbTypeMap<SqlDbType>? FindByClrType(Type clrType)
         {
             var existing = typeMaps.FirstOrDefault(x => x.ClrType == clrType);
-            if (existing is object)
+            if (existing is not null)
                 return existing;
 
             if (clrType.IsEnum)
@@ -119,6 +132,12 @@ namespace HatTrick.DbEx.MsSql.Types
 
             return null;
         }
+
+        public bool IsUnicode(DbType dbType)
+            => unicodeDbTypes.Contains(dbType);
+
+        public bool IsUnicode(SqlDbType platformType)
+            => unicodePlatformTypes.Contains(platformType);
         #endregion
     }
 }

--- a/src/HatTrick.DbEx.MsSql/_Extensions/Configuration/SqlDatabaseRuntimeServiceBuilderExtensions.cs
+++ b/src/HatTrick.DbEx.MsSql/_Extensions/Configuration/SqlDatabaseRuntimeServiceBuilderExtensions.cs
@@ -379,7 +379,6 @@ namespace HatTrick.DbEx.MsSql.Configuration
             where TDatabase : class, ISqlDatabaseRuntime
         {
             builder.Use(sp => new DefaultQueryExpressionFactoryWithDiscovery(
-                    sp.GetRequiredService<ILogger<DefaultQueryExpressionFactoryWithDiscovery>>(),
                     t =>
                     {
                         if (sp.IsRegisteredIn<TDatabase>(t))
@@ -395,7 +394,6 @@ namespace HatTrick.DbEx.MsSql.Configuration
             where TDatabase : class, ISqlDatabaseRuntime
         {
             builder.Creation.Use(sp => new DefaultEntityFactoryWithFallbackConstruction(
-                    sp.GetRequiredService<ILogger<DefaultEntityFactoryWithFallbackConstruction>>(),
                     t =>
                     {
                         if (sp.IsRegisteredIn<TDatabase>(t))
@@ -445,7 +443,6 @@ namespace HatTrick.DbEx.MsSql.Configuration
             where TDatabase : class, ISqlDatabaseRuntime
         {
             builder.Assembly.ElementAppender.Use(sp => new DefaultExpressionElementAppenderFactoryWithDiscovery(
-                    sp.GetRequiredService<ILogger<DefaultExpressionElementAppenderFactoryWithDiscovery>>(),
                     t =>
                     {
                         if (sp.IsRegisteredIn<TDatabase>(t))

--- a/src/HatTrick.DbEx.MsSql/_Extensions/Configuration/SqlDatabaseRuntimeServiceBuilderExtensions_Defaults.cs
+++ b/src/HatTrick.DbEx.MsSql/_Extensions/Configuration/SqlDatabaseRuntimeServiceBuilderExtensions_Defaults.cs
@@ -26,7 +26,7 @@ namespace HatTrick.DbEx.MsSql.Configuration
 {
     public static partial class SqlDatabaseRuntimeServiceBuilderExtensions
     {
-        public static void WithDefaults<TDatabase>(IExpressionElementAppenderFactoryContinuationConfigurationBuilder<TDatabase> builder)
+        public static void WithDefaults<TDatabase>(this IExpressionElementAppenderFactoryContinuationConfigurationBuilder<TDatabase> builder)
             where TDatabase : class, ISqlDatabaseRuntime
         {
             builder

--- a/src/HatTrick.DbEx.Sql/Assembler/AppenderIndentation.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/AppenderIndentation.cs
@@ -61,10 +61,10 @@ namespace HatTrick.DbEx.Sql.Assembler
         public IAppender Write(char value)
             => appender.Write(value);
 
-        public IAppender If(bool append, params Action<Appender>[] values)
+        public IAppender If(bool append, params Action<IAppender>[] values)
             => appender.If(append, values);
 
-        public IAppender IfNotEmpty(string test, params Action<Appender>[] values)
+        public IAppender IfNotEmpty(string test, params Action<IAppender>[] values)
             => appender.IfNotEmpty(test, values);
 
         public IAppender Indent()

--- a/src/HatTrick.DbEx.Sql/Assembler/AssemblyContext.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/AssemblyContext.cs
@@ -37,18 +37,9 @@ namespace HatTrick.DbEx.Sql.Assembler
         public bool PrependCommaOnSelectClause { get; set; } = false;
         public SqlStatementAssemblyOptions.Delimeters IdentifierDelimiter { get; set; } = new SqlStatementAssemblyOptions.Delimeters('[', ']');
         public char StatementTerminator { get; set; } = ';';
-        public FieldExpressionAppendStyle FieldExpressionAppendStyle => fieldStyles.FirstOrDefault();
-        public EntityExpressionAppendStyle EntityExpressionAppendStyle => entityStyles.FirstOrDefault();
+        public FieldExpressionAppendStyle FieldExpressionAppendStyle => fieldStyles.Any() ? fieldStyles.Peek() : FieldExpressionAppendStyle.None;
+        public EntityExpressionAppendStyle EntityExpressionAppendStyle => entityStyles.Any() ? entityStyles.Peek() : EntityExpressionAppendStyle.None;
         public bool TrySharingExistingParameter { get; set; }
-        #endregion
-
-        #region constructors
-        public AssemblyContext()
-        {
-            //set defaults
-            fieldStyles.Push(FieldExpressionAppendStyle.None);
-            entityStyles.Push(EntityExpressionAppendStyle.None);
-        }
         #endregion
 
         #region methods
@@ -66,22 +57,28 @@ namespace HatTrick.DbEx.Sql.Assembler
 
         public void PopAppendStyles()
         {
-            if (entityStyles.Any())
-                entityStyles.Pop();
-            if (fieldStyles.Any())
-                fieldStyles.Pop();
+            PopEntityAppendStyle();
+            PopFieldAppendStyle();
         }
 
         public void PopEntityAppendStyle()
         {
+#if NET6_0_OR_GREATER
+            entityStyles.TryPop(out var _);
+#else
             if (entityStyles.Any())
                 entityStyles.Pop();
+#endif
         }
 
         public void PopFieldAppendStyle()
         {
+#if NET6_0_OR_GREATER
+            fieldStyles.TryPop(out var _);
+#else
             if (fieldStyles.Any())
                 fieldStyles.Pop();
+#endif        
         }
 
         public void SetState<T>()
@@ -108,6 +105,6 @@ namespace HatTrick.DbEx.Sql.Assembler
                 state.Remove(typeof(T));
             return existing;
         }
-        #endregion
+#endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Assembler/DefaultExpressionElementAppenderFactoryWithDiscovery.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/DefaultExpressionElementAppenderFactoryWithDiscovery.cs
@@ -17,34 +17,31 @@
 #endregion
 
 using HatTrick.DbEx.Sql.Expression;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 
 namespace HatTrick.DbEx.Sql.Assembler
 {
-    public class DefaultExpressionElementAppenderFactoryWithDiscovery : IExpressionElementAppenderFactory
+    public sealed class DefaultExpressionElementAppenderFactoryWithDiscovery : IExpressionElementAppenderFactory
     {
         #region internals
-        private readonly ILogger<DefaultExpressionElementAppenderFactoryWithDiscovery> logger;
         private readonly Func<Type, IExpressionElementAppender?> overrides;
-        private readonly ConcurrentDictionary<Type, Func<Type, IExpressionElementAppender?>> appenders = new();
+        private readonly ConcurrentDictionary<TypeDictionaryKey, Type?> appenderTypes = new();
         #endregion
 
         #region constructors
-        public DefaultExpressionElementAppenderFactoryWithDiscovery(ILogger<DefaultExpressionElementAppenderFactoryWithDiscovery> logger, Func<Type, IExpressionElementAppender?> overrides)
+        public DefaultExpressionElementAppenderFactoryWithDiscovery(Func<Type, IExpressionElementAppender?> overrides)
         {
-            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.overrides = overrides ?? throw new ArgumentNullException(nameof(overrides));
         }
         #endregion
 
         #region methods
-        public virtual IExpressionElementAppender<T> CreateElementAppender<T>()
+        public IExpressionElementAppender<T> CreateElementAppender<T>()
             where T : class, IExpressionElement
             => (CreateElementAppender(typeof(T)) as IExpressionElementAppender<T>)!;
 
-        public virtual IExpressionElementAppender CreateElementAppender(Type type)
+        public IExpressionElementAppender CreateElementAppender(Type type)
         {
             if (TryResolveElementAppender(type, out IExpressionElementAppender? appender))
                 return appender!;
@@ -52,14 +49,12 @@ namespace HatTrick.DbEx.Sql.Assembler
             throw new DbExpressionConfigurationException($"Could not resolve an element appender for type '{type}'.");
         }
 
-        protected virtual bool TryResolveElementAppender(Type type, out IExpressionElementAppender? appender)
+        private bool TryResolveElementAppender(Type type, out IExpressionElementAppender? appender)
         {
             appender = default;
             try
             {
-                var factory = ResolveElementAppender(type, type);
-                if (factory is not null)
-                    appender = factory(type);
+                appender = ResolveElementAppender(type, type);
             }
             catch
             {
@@ -68,30 +63,50 @@ namespace HatTrick.DbEx.Sql.Assembler
             return appender is not null;
         }
 
-        protected virtual Func<Type, IExpressionElementAppender?>? ResolveElementAppender(Type currentType, Type requestedType)
+        private IExpressionElementAppender? ResolveElementAppender(Type currentType, Type requestedType)
         {
             if (currentType is null)
                 return null;
 
-            if (appenders.TryGetValue(currentType, out Func<Type, IExpressionElementAppender?>? factory))
+            var key = new TypeDictionaryKey(currentType.TypeHandle.Value);
+            if (!appenderTypes.TryGetValue(key, out Type? _))
             {
-                if (currentType != requestedType)
-                    appenders.TryAdd(requestedType, factory);
-                return factory;
+                appenderTypes.TryAdd(key, typeof(IExpressionElementAppender<>).MakeGenericType(new[] { currentType }));
             }
 
-            var elementAppenderType = typeof(IExpressionElementAppender<>).MakeGenericType(new[] { currentType });
-            var @override = overrides(elementAppenderType);
+            var @override = overrides(appenderTypes[key]!);
             if (@override is not null)
             {
-                appenders.TryAdd(requestedType, t => overrides(elementAppenderType));
-                return appenders[requestedType];
+                return @override;
             }
 
             if (currentType.BaseType is null)
                 return null;
 
             return ResolveElementAppender(currentType.BaseType, requestedType);
+        }
+        #endregion
+
+        #region classes
+        private readonly struct TypeDictionaryKey : IEquatable<TypeDictionaryKey>
+        {
+            #region interface
+            public readonly IntPtr Ptr;
+            #endregion
+
+            #region constructors
+            public TypeDictionaryKey(IntPtr key) => Ptr = key;
+            #endregion
+
+            #region methods
+            public bool Equals(TypeDictionaryKey other)
+                => Ptr == other.Ptr;
+
+            public override int GetHashCode() => Ptr.GetHashCode();
+
+            public override bool Equals(object? obj)
+                => obj is TypeDictionaryKey other && Equals(other);
+            #endregion
         }
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Assembler/DelegateExpressionElementAppenderFactory.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/DelegateExpressionElementAppenderFactory.cs
@@ -42,8 +42,8 @@ namespace HatTrick.DbEx.Sql.Assembler
             if (elementType is null)
                 throw new ArgumentNullException(nameof(elementType));
 
-            if (map.ContainsKey(elementType))
-                return factory(map[elementType]);
+            if (map.TryGetValue(elementType, out Type? value))
+                return factory(value);
 
             map.Add(elementType, typeof(IExpressionElementAppender<>).MakeGenericType(new[] { elementType }));
 

--- a/src/HatTrick.DbEx.Sql/Assembler/IAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/IAppender.cs
@@ -20,7 +20,7 @@
 
 namespace HatTrick.DbEx.Sql.Assembler
 {
-    public interface IAppender
+    public interface IAppender : IDisposable
     {
         AppenderIndentation Indentation { get; set; }
 
@@ -31,9 +31,9 @@ namespace HatTrick.DbEx.Sql.Assembler
         IAppender Write(char value);
         IAppender Indent();
 
-        IAppender If(bool append, params Action<Appender>[] values);
+        IAppender If(bool append, params Action<IAppender>[] values);
 
-        IAppender IfNotEmpty(string test, params Action<Appender>[] values);
+        IAppender IfNotEmpty(string test, params Action<IAppender>[] values);
 
         string? ToString();
     }

--- a/src/HatTrick.DbEx.Sql/Builder/_Delete/DeleteEntitiesDeleteQueryExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/_Delete/DeleteEntitiesDeleteQueryExpressionBuilder{T,U}.cs
@@ -134,7 +134,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<int> DeleteEntitiesTermination<TDatabase>.ExecuteAsync(CancellationToken cancellationToken)
+        ValueTask<int> DeleteEntitiesTermination<TDatabase>.ExecuteAsync(CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 null,
@@ -144,7 +144,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<int> DeleteEntitiesTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
+        ValueTask<int> DeleteEntitiesTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -154,7 +154,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<int> DeleteEntitiesTermination<TDatabase>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
+        ValueTask<int> DeleteEntitiesTermination<TDatabase>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -167,7 +167,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<int> DeleteEntitiesTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
+        ValueTask<int> DeleteEntitiesTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -182,7 +182,7 @@ namespace HatTrick.DbEx.Sql.Builder
         private int ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand)
             => ExecutionPipelineFactory().ExecuteDelete(DeleteQueryExpression, connection, configureCommand);
 
-        private Task<int> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
+        private ValueTask<int> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
             => ExecutionPipelineFactory().ExecuteDeleteAsync(DeleteQueryExpression, connection, configureCommand, cancellationToken);
         #endregion
         #endregion

--- a/src/HatTrick.DbEx.Sql/Builder/_Select/SelectDynamicsSelectQueryExpressionBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/_Select/SelectDynamicsSelectQueryExpressionBuilder{T}.cs
@@ -338,7 +338,7 @@ namespace HatTrick.DbEx.Sql.Builder
 
         #region SelectDynamicsTermination<TDatabase>
         /// <inheritdoc />
-        IEnumerable<dynamic> SelectDynamicsTermination<TDatabase>.Execute()
+        IList<dynamic> SelectDynamicsTermination<TDatabase>.Execute()
         {
             return ExecutePipeline(
                 null,
@@ -347,7 +347,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<dynamic> SelectDynamicsTermination<TDatabase>.Execute(int commandTimeout)
+        IList<dynamic> SelectDynamicsTermination<TDatabase>.Execute(int commandTimeout)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -359,7 +359,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<dynamic> SelectDynamicsTermination<TDatabase>.Execute(ISqlConnection connection)
+        IList<dynamic> SelectDynamicsTermination<TDatabase>.Execute(ISqlConnection connection)
         {
             return ExecutePipeline(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -368,7 +368,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<dynamic> SelectDynamicsTermination<TDatabase>.Execute(ISqlConnection connection, int commandTimeout)
+        IList<dynamic> SelectDynamicsTermination<TDatabase>.Execute(ISqlConnection connection, int commandTimeout)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -380,7 +380,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<dynamic>> SelectDynamicsTermination<TDatabase>.ExecuteAsync(CancellationToken cancellationToken)
+        Task<IList<dynamic>> SelectDynamicsTermination<TDatabase>.ExecuteAsync(CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 null,
@@ -400,7 +400,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<dynamic>> SelectDynamicsTermination<TDatabase>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
+        Task<IList<dynamic>> SelectDynamicsTermination<TDatabase>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -426,7 +426,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<dynamic>> SelectDynamicsTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
+        Task<IList<dynamic>> SelectDynamicsTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -446,7 +446,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<dynamic>> SelectDynamicsTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
+        Task<IList<dynamic>> SelectDynamicsTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -472,7 +472,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<T> SelectDynamicsTermination<TDatabase>.Execute<T>(Func<ISqlFieldReader, T> map)
+        IList<T> SelectDynamicsTermination<TDatabase>.Execute<T>(Func<ISqlFieldReader, T> map)
         {
             return ExecutePipeline<T>(
                 null,
@@ -482,7 +482,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<T> SelectDynamicsTermination<TDatabase>.Execute<T>(int commandTimeout, Func<ISqlFieldReader, T> map)
+        IList<T> SelectDynamicsTermination<TDatabase>.Execute<T>(int commandTimeout, Func<ISqlFieldReader, T> map)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -495,7 +495,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<T> SelectDynamicsTermination<TDatabase>.Execute<T>(ISqlConnection? connection, Func<ISqlFieldReader, T> map)
+        IList<T> SelectDynamicsTermination<TDatabase>.Execute<T>(ISqlConnection connection, Func<ISqlFieldReader, T> map)
         {
             return ExecutePipeline(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -505,7 +505,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<T> SelectDynamicsTermination<TDatabase>.Execute<T>(ISqlConnection? connection, int commandTimeout, Func<ISqlFieldReader, T> map)
+        IList<T> SelectDynamicsTermination<TDatabase>.Execute<T>(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, T> map)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -564,7 +564,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<T>> SelectDynamicsTermination<TDatabase>.ExecuteAsync<T>(Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+        Task<IList<T>> SelectDynamicsTermination<TDatabase>.ExecuteAsync<T>(Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 null,
@@ -586,7 +586,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<T>> SelectDynamicsTermination<TDatabase>.ExecuteAsync<T>(int commandTimeout, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+        Task<IList<T>> SelectDynamicsTermination<TDatabase>.ExecuteAsync<T>(int commandTimeout, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -614,7 +614,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<T>> SelectDynamicsTermination<TDatabase>.ExecuteAsync<T>(ISqlConnection? connection, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+        Task<IList<T>> SelectDynamicsTermination<TDatabase>.ExecuteAsync<T>(ISqlConnection connection, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -625,7 +625,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IAsyncEnumerable<T> SelectDynamicsTermination<TDatabase>.ExecuteAsyncEnumerable<T>(ISqlConnection? connection, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+        IAsyncEnumerable<T> SelectDynamicsTermination<TDatabase>.ExecuteAsyncEnumerable<T>(ISqlConnection connection, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsyncEnumerable(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -636,7 +636,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<T>> SelectDynamicsTermination<TDatabase>.ExecuteAsync<T>(ISqlConnection? connection, int commandTimeout, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+        Task<IList<T>> SelectDynamicsTermination<TDatabase>.ExecuteAsync<T>(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -650,7 +650,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IAsyncEnumerable<T> SelectDynamicsTermination<TDatabase>.ExecuteAsyncEnumerable<T>(ISqlConnection? connection, int commandTimeout, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
+        IAsyncEnumerable<T> SelectDynamicsTermination<TDatabase>.ExecuteAsyncEnumerable<T>(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -764,16 +764,16 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         #region execute pipeline
-        private IEnumerable<dynamic> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand)
+        private IList<dynamic> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand)
             => CreateExecutionPipeline().ExecuteSelectDynamicList(SelectQueryExpression, connection, configureCommand);
 
         private void ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader> read)
             => CreateExecutionPipeline().ExecuteSelectDynamicList(SelectQueryExpression, connection, configureCommand, read);
 
-        private IEnumerable<T> ExecutePipeline<T>(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T> map)
+        private IList<T> ExecutePipeline<T>(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T> map)
             => CreateExecutionPipeline().ExecuteSelectObjectList(SelectQueryExpression, connection, configureCommand, map);
 
-        private Task<IEnumerable<dynamic>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
+        private Task<IList<dynamic>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
             => CreateExecutionPipeline().ExecuteSelectDynamicListAsync(SelectQueryExpression, connection, configureCommand, cancellationToken);
 
         private IAsyncEnumerable<dynamic> ExecutePipelineAsyncEnumerable(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
@@ -785,7 +785,7 @@ namespace HatTrick.DbEx.Sql.Builder
         private Task ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, Task> map, CancellationToken cancellationToken)
             => CreateExecutionPipeline().ExecuteSelectDynamicListAsync(SelectQueryExpression, connection, configureCommand, map, cancellationToken);
 
-        private Task<IEnumerable<T>> ExecutePipelineAsync<T>(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T> read, CancellationToken cancellationToken)
+        private Task<IList<T>> ExecutePipelineAsync<T>(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T> read, CancellationToken cancellationToken)
             => CreateExecutionPipeline().ExecuteSelectObjectListAsync(SelectQueryExpression, connection, configureCommand, read, cancellationToken);
 
         private IAsyncEnumerable<T> ExecutePipelineAsyncEnumerable<T>(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T> read, CancellationToken cancellationToken)

--- a/src/HatTrick.DbEx.Sql/Builder/_Select/SelectEntitiesSelectQueryExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/_Select/SelectEntitiesSelectQueryExpressionBuilder{T,U}.cs
@@ -301,7 +301,7 @@ namespace HatTrick.DbEx.Sql.Builder
 
         #region SelectEntitiesTermination<TDatabase, TEntity>
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute()
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute()
         {
             return ExecutePipeline(
                 null,
@@ -310,7 +310,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(int commandTimeout)
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(int commandTimeout)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -322,7 +322,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection)
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection)
         {
             return ExecutePipeline(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -331,7 +331,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection, int commandTimeout)
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection, int commandTimeout)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -343,7 +343,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(Func<ISqlFieldReader, TEntity> map)
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(Func<ISqlFieldReader, TEntity> map)
         {
             return ExecutePipeline(
                 null,
@@ -353,7 +353,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(int commandTimeout, Func<ISqlFieldReader, TEntity> map)
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(int commandTimeout, Func<ISqlFieldReader, TEntity> map)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -366,7 +366,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection, Func<ISqlFieldReader, TEntity> map)
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection, Func<ISqlFieldReader, TEntity> map)
         {
             return ExecutePipeline(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -376,7 +376,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map)
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -435,7 +435,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(Action<ISqlFieldReader, TEntity> map)
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(Action<ISqlFieldReader, TEntity> map)
         {
             return ExecutePipeline(
                 null,
@@ -445,7 +445,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(int commandTimeout, Action<ISqlFieldReader, TEntity> map)
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(int commandTimeout, Action<ISqlFieldReader, TEntity> map)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -458,7 +458,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection, Action<ISqlFieldReader, TEntity> map)
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection, Action<ISqlFieldReader, TEntity> map)
         {
             return ExecutePipeline(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -468,7 +468,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map)
+        IList<TEntity> SelectEntitiesTermination<TDatabase, TEntity>.Execute(ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -481,7 +481,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 null,
@@ -501,7 +501,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -527,7 +527,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -547,7 +547,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -623,7 +623,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 null,
@@ -645,7 +645,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -673,7 +673,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -695,7 +695,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -723,7 +723,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 null,
@@ -745,7 +745,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -773,7 +773,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -795,7 +795,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -873,7 +873,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 null,
@@ -895,7 +895,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -923,7 +923,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -945,7 +945,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken)
+        Task<IList<TEntity>> SelectEntitiesTermination<TDatabase, TEntity>.ExecuteAsync(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -973,34 +973,34 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         #region execute pipeline
-        private IEnumerable<TEntity> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand)
+        private IList<TEntity> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand)
             => CreateExecutionPipeline().ExecuteSelectEntityList<TEntity>(SelectQueryExpression, table, connection, configureCommand);
 
-        private IEnumerable<TEntity> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity> map)
+        private IList<TEntity> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity> map)
             => CreateExecutionPipeline().ExecuteSelectEntityList<TEntity>(SelectQueryExpression, table, connection, configureCommand, map);
 
         private void ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader> read)
             => CreateExecutionPipeline().ExecuteSelectEntityList<TEntity>(SelectQueryExpression, table, connection, configureCommand, read);
 
-        private IEnumerable<TEntity> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map)
+        private IList<TEntity> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map)
             => CreateExecutionPipeline().ExecuteSelectEntityList<TEntity>(SelectQueryExpression, table, connection, configureCommand, map);
 
-        private Task<IEnumerable<TEntity>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
+        private Task<IList<TEntity>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
             => CreateExecutionPipeline().ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression, table, connection, configureCommand, cancellationToken);
 
         private Task ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader> read, CancellationToken cancellationToken)
             => CreateExecutionPipeline().ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression, table, connection, configureCommand, read, cancellationToken);
 
-        private Task<IEnumerable<TEntity>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
+        private Task<IList<TEntity>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
             => CreateExecutionPipeline().ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression, table, connection, configureCommand, map, cancellationToken);
 
-        private Task<IEnumerable<TEntity>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
+        private Task<IList<TEntity>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken)
             => CreateExecutionPipeline().ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression, table, connection, configureCommand, map, cancellationToken);
 
         private Task ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, Task> map, CancellationToken cancellationToken)
             => CreateExecutionPipeline().ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression, table, connection, configureCommand, map, cancellationToken);
 
-        private Task<IEnumerable<TEntity>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken)
+        private Task<IList<TEntity>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken)
             => CreateExecutionPipeline().ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression, table, connection, configureCommand, map, cancellationToken);
 
         private IAsyncEnumerable<TEntity> ExecutePipelineAsyncEnumerable(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)

--- a/src/HatTrick.DbEx.Sql/Builder/_Select/SelectObjectsSelectQueryExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/_Select/SelectObjectsSelectQueryExpressionBuilder{T,U}.cs
@@ -250,7 +250,7 @@ namespace HatTrick.DbEx.Sql.Builder
 
         #region SelectObjectsTermination<TObject>
         /// <inheritdoc />
-        IEnumerable<TObject> SelectObjectsTermination<TDatabase, TObject>.Execute()
+        IList<TObject> SelectObjectsTermination<TDatabase, TObject>.Execute()
         {
             return ExecutePipeline(
                 null,
@@ -259,7 +259,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TObject> SelectObjectsTermination<TDatabase, TObject>.Execute(int commandTimeout)
+        IList<TObject> SelectObjectsTermination<TDatabase, TObject>.Execute(int commandTimeout)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -271,7 +271,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TObject> SelectObjectsTermination<TDatabase, TObject>.Execute(ISqlConnection connection)
+        IList<TObject> SelectObjectsTermination<TDatabase, TObject>.Execute(ISqlConnection connection)
         {
             return ExecutePipeline(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -280,7 +280,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TObject> SelectObjectsTermination<TDatabase, TObject>.Execute(ISqlConnection connection, int commandTimeout)
+        IList<TObject> SelectObjectsTermination<TDatabase, TObject>.Execute(ISqlConnection connection, int commandTimeout)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -338,7 +338,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TObject>> SelectObjectsTermination<TDatabase, TObject>.ExecuteAsync(CancellationToken cancellationToken)
+        Task<IList<TObject>> SelectObjectsTermination<TDatabase, TObject>.ExecuteAsync(CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 null,
@@ -348,7 +348,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TObject>> SelectObjectsTermination<TDatabase, TObject>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
+        Task<IList<TObject>> SelectObjectsTermination<TDatabase, TObject>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -361,7 +361,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TObject>> SelectObjectsTermination<TDatabase, TObject>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
+        Task<IList<TObject>> SelectObjectsTermination<TDatabase, TObject>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -371,7 +371,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TObject>> SelectObjectsTermination<TDatabase, TObject>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
+        Task<IList<TObject>> SelectObjectsTermination<TDatabase, TObject>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -483,10 +483,10 @@ namespace HatTrick.DbEx.Sql.Builder
             );
         }
 
-        private IEnumerable<TObject> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand)
+        private IList<TObject> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand)
             => CreateExecutionPipeline().ExecuteSelectValueList<TObject>(SelectQueryExpression, connection, configureCommand);
 
-        private Task<IEnumerable<TObject>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
+        private Task<IList<TObject>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
             => CreateExecutionPipeline().ExecuteSelectValueListAsync<TObject>(SelectQueryExpression, connection, configureCommand, cancellationToken);
 
         private void ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<TObject?> read)

--- a/src/HatTrick.DbEx.Sql/Builder/_Select/SelectValuesSelectQueryExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/_Select/SelectValuesSelectQueryExpressionBuilder{T,U}.cs
@@ -328,7 +328,7 @@ namespace HatTrick.DbEx.Sql.Builder
 
         #region SelectValuesTermination<TDatabase, TValue>
         /// <inheritdoc />
-        IEnumerable<TValue> SelectValuesTermination<TDatabase, TValue>.Execute()
+        IList<TValue> SelectValuesTermination<TDatabase, TValue>.Execute()
         {
             return ExecutePipeline(
                 null,
@@ -337,7 +337,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TValue> SelectValuesTermination<TDatabase, TValue>.Execute(int commandTimeout)
+        IList<TValue> SelectValuesTermination<TDatabase, TValue>.Execute(int commandTimeout)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -349,7 +349,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TValue> SelectValuesTermination<TDatabase, TValue>.Execute(ISqlConnection connection)
+        IList<TValue> SelectValuesTermination<TDatabase, TValue>.Execute(ISqlConnection connection)
         {
             return ExecutePipeline(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -358,7 +358,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        IEnumerable<TValue> SelectValuesTermination<TDatabase, TValue>.Execute(ISqlConnection connection, int commandTimeout)
+        IList<TValue> SelectValuesTermination<TDatabase, TValue>.Execute(ISqlConnection connection, int commandTimeout)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -416,7 +416,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TValue>> SelectValuesTermination<TDatabase, TValue>.ExecuteAsync(CancellationToken cancellationToken)
+        Task<IList<TValue>> SelectValuesTermination<TDatabase, TValue>.ExecuteAsync(CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 null,
@@ -436,7 +436,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TValue>> SelectValuesTermination<TDatabase, TValue>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
+        Task<IList<TValue>> SelectValuesTermination<TDatabase, TValue>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -462,7 +462,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TValue>> SelectValuesTermination<TDatabase, TValue>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
+        Task<IList<TValue>> SelectValuesTermination<TDatabase, TValue>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -482,7 +482,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<IEnumerable<TValue>> SelectValuesTermination<TDatabase, TValue>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
+        Task<IList<TValue>> SelectValuesTermination<TDatabase, TValue>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -607,10 +607,10 @@ namespace HatTrick.DbEx.Sql.Builder
             );
         }
 
-        private IEnumerable<TValue> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand)
+        private IList<TValue> ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand)
             => CreateExecutionPipeline().ExecuteSelectValueList<TValue>(SelectQueryExpression, connection, configureCommand);
 
-        private Task<IEnumerable<TValue>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
+        private Task<IList<TValue>> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
             => CreateExecutionPipeline().ExecuteSelectValueListAsync<TValue>(SelectQueryExpression, connection, configureCommand, cancellationToken);
 
         private IAsyncEnumerable<TValue> ExecutePipelineAsyncEnumerable(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)

--- a/src/HatTrick.DbEx.Sql/Builder/_Update/UpdateEntitiesUpdateQueryExpressionBuilder{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/Builder/_Update/UpdateEntitiesUpdateQueryExpressionBuilder{T,U}.cs
@@ -145,7 +145,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<int> UpdateEntitiesTermination<TDatabase>.ExecuteAsync(CancellationToken cancellationToken)
+        ValueTask<int> UpdateEntitiesTermination<TDatabase>.ExecuteAsync(CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 null,
@@ -155,7 +155,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<int> UpdateEntitiesTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
+        ValueTask<int> UpdateEntitiesTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken)
         {
             return ExecutePipelineAsync(
                 connection ?? throw new ArgumentNullException(nameof(connection)),
@@ -165,7 +165,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<int> UpdateEntitiesTermination<TDatabase>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
+        ValueTask<int> UpdateEntitiesTermination<TDatabase>.ExecuteAsync(int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -178,7 +178,7 @@ namespace HatTrick.DbEx.Sql.Builder
         }
 
         /// <inheritdoc />
-        Task<int> UpdateEntitiesTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
+        ValueTask<int> UpdateEntitiesTermination<TDatabase>.ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken)
         {
             if (commandTimeout <= 0)
                 throw new ArgumentException($"{nameof(commandTimeout)} must be a number greater than 0.");
@@ -193,7 +193,7 @@ namespace HatTrick.DbEx.Sql.Builder
         private int ExecutePipeline(ISqlConnection? connection, Action<IDbCommand>? configureCommand)
             => ExecutionPipelineFactory().ExecuteUpdate(UpdateQueryExpression, connection, configureCommand);
 
-        private Task<int> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
+        private ValueTask<int> ExecutePipelineAsync(ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken cancellationToken)
             => ExecutionPipelineFactory().ExecuteUpdateAsync(UpdateQueryExpression, connection, configureCommand, cancellationToken);
         #endregion
         #endregion

--- a/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Creation/EntityFactoryConfigurationBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_Entities/_Creation/EntityFactoryConfigurationBuilder{T}.cs
@@ -81,11 +81,7 @@ namespace HatTrick.DbEx.Sql.Configuration
             if (factory is null)
                 throw new ArgumentNullException(nameof(factory));
 
-            services.TryAddSingleton<IEntityFactory>(sp => new DefaultEntityFactoryWithFallbackConstruction(
-                    sp.GetRequiredService<ILogger<DefaultEntityFactoryWithFallbackConstruction>>(), 
-                    t => factory(t)
-                )
-            );
+            services.TryAddSingleton<IEntityFactory>(sp => new DefaultEntityFactoryWithFallbackConstruction(t => factory(t)));
             return caller;
         }
 
@@ -95,11 +91,7 @@ namespace HatTrick.DbEx.Sql.Configuration
             if (factory is null)
                 throw new ArgumentNullException(nameof(factory));
 
-            services.TryAddSingleton<IEntityFactory>(sp => new DefaultEntityFactoryWithFallbackConstruction(
-                    sp.GetRequiredService<ILogger<DefaultEntityFactoryWithFallbackConstruction>>(),
-                    t => factory(sp, t)
-                )
-            );
+            services.TryAddSingleton<IEntityFactory>(sp => new DefaultEntityFactoryWithFallbackConstruction(t => factory(sp, t)));
             return caller;
         }
 
@@ -109,11 +101,7 @@ namespace HatTrick.DbEx.Sql.Configuration
             if (factory is null)
                 throw new ArgumentNullException(nameof(factory));
 
-            services.TryAddSingleton<IEntityFactory>(sp => new DefaultEntityFactoryWithFallbackConstruction(
-                    sp.GetRequiredService<ILogger<DefaultEntityFactoryWithFallbackConstruction>>(),
-                    t => factory(sp, t)
-                )
-            );
+            services.TryAddSingleton<IEntityFactory>(sp => new DefaultEntityFactoryWithFallbackConstruction(t => factory(sp, t)));
             configureEntityTypes.Invoke(new EntityFactoryConfigurationBuilder<TDatabase>(caller, services));
             return caller;
         }
@@ -124,7 +112,7 @@ namespace HatTrick.DbEx.Sql.Configuration
             if (factory is null)
                 throw new ArgumentNullException(nameof(factory));
 
-            services.TryAddTransient<IEntityFactory>(factory);
+            services.TryAddSingleton<IEntityFactory>(factory);
             return caller;
         }
 

--- a/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/_Assembly/ExpressionElementAppenderFactoryConfigurationBuilder{T}.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/_Assembly/ExpressionElementAppenderFactoryConfigurationBuilder{T}.cs
@@ -75,11 +75,7 @@ namespace HatTrick.DbEx.Sql.Configuration
             if (factory is null)
                 throw new ArgumentNullException(nameof(factory));
 
-            services.TryAddSingleton<IExpressionElementAppenderFactory>(sp => new DefaultExpressionElementAppenderFactoryWithDiscovery(
-                    sp.GetRequiredService<ILogger<DefaultExpressionElementAppenderFactoryWithDiscovery>>(),
-                    factory
-                )
-            );
+            services.TryAddSingleton<IExpressionElementAppenderFactory>(sp => new DefaultExpressionElementAppenderFactoryWithDiscovery(factory));
             return caller;
         }
 
@@ -89,11 +85,7 @@ namespace HatTrick.DbEx.Sql.Configuration
             if (factory is null)
                 throw new ArgumentNullException(nameof(factory));
 
-            services.TryAddSingleton<IExpressionElementAppenderFactory>(sp => new DefaultExpressionElementAppenderFactoryWithDiscovery(
-                    sp.GetRequiredService<ILogger<DefaultExpressionElementAppenderFactoryWithDiscovery>>(),
-                    t => factory(sp, t)
-                )
-            );
+            services.TryAddSingleton<IExpressionElementAppenderFactory>(sp => new DefaultExpressionElementAppenderFactoryWithDiscovery(t => factory(sp, t)));
             return caller;
         }
 
@@ -106,11 +98,7 @@ namespace HatTrick.DbEx.Sql.Configuration
             if (configureElementTypes is null)
                 throw new ArgumentNullException(nameof(configureElementTypes));
 
-            services.TryAddSingleton<IExpressionElementAppenderFactory>(sp => new DefaultExpressionElementAppenderFactoryWithDiscovery(
-                    sp.GetRequiredService<ILogger<DefaultExpressionElementAppenderFactoryWithDiscovery>>(),
-                    t => factory(sp, t)
-                )
-            );
+            services.TryAddSingleton<IExpressionElementAppenderFactory>(sp => new DefaultExpressionElementAppenderFactoryWithDiscovery(t => factory(sp, t)));
             configureElementTypes.Invoke(new ExpressionElementAppenderFactoryContinuationConfigurationBuilder<TDatabase>(services));
             return caller;
         }

--- a/src/HatTrick.DbEx.Sql/Connection/SqlConnector.cs
+++ b/src/HatTrick.DbEx.Sql/Connection/SqlConnector.cs
@@ -29,7 +29,7 @@ namespace HatTrick.DbEx.Sql.Connection
         #region i sql connection
         private bool disposed;
         protected IDbConnection? _dbConnection;
-        protected Func<IDbConnection> _connectionFactory;
+        protected Lazy<IDbConnection> _connectionFactory;
 
         public IDbTransaction? DbTransaction { get; private set; }
 
@@ -50,18 +50,17 @@ namespace HatTrick.DbEx.Sql.Connection
 
         public SqlConnector(IDbConnectionFactory connectionFactory)
         {
-            _connectionFactory = new Func<IDbConnection>(() => (connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory))).CreateSqlConnection());
+            _connectionFactory = new Lazy<IDbConnection>(() => (connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory))).CreateSqlConnection());
         }
 
         public SqlConnector(IDbConnection connection)
         {
-            _connectionFactory = new Func<IDbConnection>(() => connection ?? throw new ArgumentNullException(nameof(connection)));
+            _connectionFactory = new Lazy<IDbConnection>(() => connection ?? throw new ArgumentNullException(nameof(connection)));
         }
 
         protected void EnsureConnection()
         {
-            if (_dbConnection is null)
-                _dbConnection = _connectionFactory.Invoke();
+            _dbConnection ??= _connectionFactory.Value;
         }
 
         public void EnsureOpen()

--- a/src/HatTrick.DbEx.Sql/Converter/DefaultValueConverterFactoryWithDiscovery.cs
+++ b/src/HatTrick.DbEx.Sql/Converter/DefaultValueConverterFactoryWithDiscovery.cs
@@ -22,12 +22,14 @@ using System.Collections.Concurrent;
 
 namespace HatTrick.DbEx.Sql.Converter
 {
-    public class DefaultValueConverterFactoryWithDiscovery : IValueConverterFactory
+    public sealed class DefaultValueConverterFactoryWithDiscovery : IValueConverterFactory
     {
         #region internals
         private readonly ILogger<DefaultValueConverterFactoryWithDiscovery> logger;
         private readonly Func<Type, IValueConverter?> overrides;
-        private readonly ConcurrentDictionary<Type, Func<Type, IValueConverter?>> converters = new();
+
+        private readonly ConcurrentDictionary<TypeDictionaryKey, Type?> converterTypes = new();
+        private readonly ConcurrentDictionary<TypeDictionaryKey, IValueConverter> defaultConverters = new();
         #endregion
 
         #region constructors
@@ -56,18 +58,18 @@ namespace HatTrick.DbEx.Sql.Converter
             throw new DbExpressionConfigurationException($"Could not resolve a value converter for type '{type}'.");
         }
 
-        protected virtual bool TryResolveValueConverter(Type type, out IValueConverter? converter)
+        private bool TryResolveValueConverter(Type type, out IValueConverter? converter)
         {
             converter = default;
             try
             {
-                var factory = ResolveValueConverter(type, type);
-                if (factory is not null)
+                converter = ResolveValueConverter(type, type);
+                if (converter is not null)
                 {
-                    converter = factory(type);
                     return true;
                 }
-                TryCreateValueConverter(type, out converter);
+                if (TryCreateValueConverter(type, out converter))
+                    defaultConverters.TryAdd(new TypeDictionaryKey(type.TypeHandle.Value), converter!);
             }
             catch
             {
@@ -78,28 +80,27 @@ namespace HatTrick.DbEx.Sql.Converter
             return converter is not null;
         }
 
-        protected virtual Func<Type, IValueConverter?>? ResolveValueConverter(Type currentType, Type requestedType)
+        private IValueConverter? ResolveValueConverter(Type currentType, Type requestedType)
         {
-            if (converters.TryGetValue(currentType, out Func<Type, IValueConverter?>? converter))
+            if (currentType is null)
+                return null;
+
+            var key = new TypeDictionaryKey(currentType.TypeHandle.Value);
+            if (!converterTypes.TryGetValue(key, out Type? _))
             {
-                if (currentType != requestedType)
-                    converters.TryAdd(requestedType, converter);
+                converterTypes.TryAdd(key, typeof(IValueConverter<>).MakeGenericType(new[] { currentType }));
+            }
+
+            if (defaultConverters.TryGetValue(key, out IValueConverter? converter))
+            {
                 return converter;
             }
 
-            if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace("Value converer for {currentType} not found in internal cache.", currentType);
-
-            var converterType = typeof(IValueConverter<>).MakeGenericType(new[] { currentType });
-            var @override = overrides(converterType);
+            var @override = overrides(converterTypes[key]!);
             if (@override is not null)
             {
-                converters.TryAdd(requestedType, t => overrides(converterType));
-                return converters[requestedType];
+                return @override;
             }
-
-            if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace("Value converter for {currentType} was not resolved via provided overrides.", currentType);
 
             if (IsEnum(currentType))
                 return null;
@@ -110,20 +111,18 @@ namespace HatTrick.DbEx.Sql.Converter
             return ResolveValueConverter(currentType.BaseType, requestedType);
         }
 
-        protected virtual bool TryCreateValueConverter(Type type, out IValueConverter? converter)
+        private bool TryCreateValueConverter(Type type, out IValueConverter? converter)
         {
             converter = default;
-            IValueConverter? created = null;
             try
             {
-                created = IsEnum(type) ? CreateEnumValueConverter(type) : CreateValueConverter(type);
+                converter = IsEnum(type) ? CreateEnumValueConverter(type) : CreateValueConverter(type);
 
-                if (created is not null)
+                if (converter is not null)
                 {
                     if (logger.IsEnabled(LogLevel.Trace))
-                        logger.LogTrace("Adding value converter {converterType} to internal cache.", created.GetType());
-                    converters.TryAdd(type, t => created);
-                    converter = created;
+                        logger.LogTrace("Adding value converter {converterType} to internal cache.", converter.GetType());
+                    defaultConverters.TryAdd(new TypeDictionaryKey(type.TypeHandle.Value), converter);
                 }
                 return converter is not null;
             }
@@ -135,7 +134,7 @@ namespace HatTrick.DbEx.Sql.Converter
             }
         }
 
-        protected virtual IValueConverter? CreateValueConverter(Type type)
+        private IValueConverter? CreateValueConverter(Type type)
         {
             if (type.IsNullableType())
             {
@@ -149,7 +148,7 @@ namespace HatTrick.DbEx.Sql.Converter
             return Activator.CreateInstance(typeof(ValueConverter<>).MakeGenericType(new[] { type })) as IValueConverter;
         }
 
-        protected virtual IValueConverter? CreateEnumValueConverter(Type type)
+        private IValueConverter? CreateEnumValueConverter(Type type)
         {
             if (type.IsNullableType())
             {
@@ -163,7 +162,7 @@ namespace HatTrick.DbEx.Sql.Converter
             return Activator.CreateInstance(typeof(EnumValueConverter<>).MakeGenericType(new[] { type })) as IValueConverter;
         }
 
-        protected virtual bool IsEnum(Type type)
+        private bool IsEnum(Type type)
         {
             if (type.IsEnum)
                 return true;
@@ -173,6 +172,29 @@ namespace HatTrick.DbEx.Sql.Converter
                 return true;
 
             return false;
+        }
+        #endregion
+
+        #region classes
+        private readonly struct TypeDictionaryKey : IEquatable<TypeDictionaryKey>
+        {
+            #region interface
+            public readonly IntPtr Ptr;
+            #endregion
+
+            #region constructors
+            public TypeDictionaryKey(IntPtr key) => Ptr = key;
+            #endregion
+
+            #region methods
+            public bool Equals(TypeDictionaryKey other)
+                => Ptr == other.Ptr;
+
+            public override int GetHashCode() => Ptr.GetHashCode();
+
+            public override bool Equals(object? obj)
+                => obj is TypeDictionaryKey other && Equals(other);
+            #endregion
         }
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Executor/Field.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/Field.cs
@@ -16,47 +16,44 @@
 // The latest version of this file can be found at https://github.com/HatTrickLabs/db-ex
 #endregion
 
-using HatTrick.DbEx.Sql.Converter;
 using System;
 
 namespace HatTrick.DbEx.Sql.Executor
 {
-    public class Field : ISqlField    
+    public readonly struct Field : ISqlField
     {
         #region internals
-        protected Func<ISqlField, Type, IValueConverter?> FindValueConverter { get; private set; }
+        private readonly IValueConverterProvider _converters;
         #endregion
 
         #region interface
-        public int Index { get; private set; }
-        public string Name { get; private set; }
-        public Type DataType { get; private set; }
-        public object RawValue { get; private set; }
+        public int Index { get; init; }
+        public string Name { get; init; }
+        public Type DataType { get; init; }
+        public object RawValue { get; init; }
         #endregion
 
         #region constructors
-        public Field(int index, string name, Type dataType, object value, Func<ISqlField, Type, IValueConverter?> findValueConverter)
+        public Field(ref int index, string name, Type dataType, object value, IValueConverterProvider converters)
         {
             Index = index;
             Name = name;
             DataType = dataType;
             RawValue = value;
-            FindValueConverter = findValueConverter ?? throw new ArgumentNullException(nameof(findValueConverter));
+            _converters = converters ?? throw new ArgumentNullException(nameof(converters));
         }
         #endregion
 
         #region methods
         public T GetValue<T>()
         {
-            var converter = FindValueConverter(this, typeof(T)) ?? throw new DbExpressionException($"Expected to find a value converter for type {typeof(T)}, but none was found.");
-
+            var converter = _converters.FindConverter(Index, typeof(T), RawValue) ?? throw new DbExpressionException($"Expected to find a value converter for type {typeof(T)}, but none was found.");
             return (T)converter.ConvertFromDatabase(RawValue is DBNull ? null : RawValue)!;
         }
 
         public object? GetValue()
         {
-            var converter = FindValueConverter(this, typeof(object)) ?? throw new DbExpressionException($"Expected to find a value converter for type {typeof(object)}, but none was found.");
-
+            var converter =_converters.FindConverter(Index, typeof(object), RawValue) ?? throw new DbExpressionException($"Expected to find a value converter for type {typeof(object)}, but none was found.");
             return converter.ConvertFromDatabase(RawValue is DBNull ? null : RawValue)!;
         }
         #endregion

--- a/src/HatTrick.DbEx.Sql/Executor/FieldTemplatedValueConverterProviderDecorator.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/FieldTemplatedValueConverterProviderDecorator.cs
@@ -1,0 +1,64 @@
+﻿#region license
+// Copyright (c) HatTrick Labs, LLC.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The latest version of this file can be found at https://github.com/HatTrickLabs/db-ex
+#endregion
+
+using HatTrick.DbEx.Sql.Converter;
+using System;
+using System.Collections.Generic;
+
+namespace HatTrick.DbEx.Sql.Executor
+{
+    internal sealed class FieldTemplatedValueConverterProviderDecorator : IValueConverterProvider
+    {
+        #region internals
+        private Dictionary<int, Type>? objectToTypeMap;
+        private readonly ISqlField[] fieldTemplates;
+        private readonly IValueConverterProvider decorated;
+        #endregion
+
+        #region constructors
+        public FieldTemplatedValueConverterProviderDecorator(ISqlField[] fieldTemplates, IValueConverterProvider decorated)
+        {
+            this.fieldTemplates = fieldTemplates ?? throw new ArgumentNullException(nameof(fieldTemplates));
+            this.decorated = decorated ?? throw new ArgumentNullException(nameof(decorated));
+        }
+        #endregion
+
+        #region methods
+        public IValueConverter? FindConverter(int fieldIndex, Type requestedType, object value)
+        {
+            if (requestedType == typeof(object))
+            {
+                objectToTypeMap ??= new();
+
+                if (objectToTypeMap.TryGetValue(fieldIndex, out Type? type))
+                {
+                    requestedType = type!;
+                }
+                else
+                {
+                    requestedType = fieldTemplates[fieldIndex].DataType.IsConvertibleToNullableType() ? typeof(Nullable<>).MakeGenericType(fieldTemplates[fieldIndex].DataType) : fieldTemplates[fieldIndex].DataType;
+                    objectToTypeMap.Add(fieldIndex, requestedType);
+                }
+            }
+
+            return decorated.FindConverter(fieldIndex, requestedType, value);
+        }
+        #endregion
+    }
+}
+

--- a/src/HatTrick.DbEx.Sql/Executor/Row.cs
+++ b/src/HatTrick.DbEx.Sql/Executor/Row.cs
@@ -21,21 +21,21 @@ using System.Collections.Generic;
 
 namespace HatTrick.DbEx.Sql.Executor
 {
-    public class Row : ISqlFieldReader
+    public struct Row : ISqlFieldReader
     {
         #region internals
-        private int fieldIndex;
-        private IList<ISqlField> fields;
+        private int fieldIndex = 0;
+        private readonly IReadOnlyList<ISqlField> fields;
         #endregion
 
         #region interface
-        public int Index { get; private set; }
+        public int Index { get; init; }
         public int FieldCount => fields.Count;
         public int CurrentFieldIndex => fieldIndex;
         #endregion
 
         #region constructors
-        public Row(int index, IList<ISqlField> fields)
+        public Row(ref int index, IReadOnlyList<ISqlField> fields)
         {
             Index = index;
             this.fields = fields ?? throw new ArgumentNullException(nameof(fields));

--- a/src/HatTrick.DbEx.Sql/Expression/DefaultQueryExpressionFactoryWithDiscovery.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/DefaultQueryExpressionFactoryWithDiscovery.cs
@@ -16,99 +16,71 @@
 // The latest version of this file can be found at https://github.com/HatTrickLabs/db-ex
 #endregion
 
-using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Concurrent;
 
 namespace HatTrick.DbEx.Sql.Expression
 {
-    public class DefaultQueryExpressionFactoryWithDiscovery : IQueryExpressionFactory
+    public sealed class DefaultQueryExpressionFactoryWithDiscovery : IQueryExpressionFactory
     {
         #region internals
-        private readonly ILogger<DefaultQueryExpressionFactoryWithDiscovery> logger;
         private readonly Func<Type, QueryExpression?> overrides;
-        private readonly ConcurrentDictionary<Type, Func<Type, QueryExpression?>> factories = new();
         #endregion
 
         #region constructors
-        public DefaultQueryExpressionFactoryWithDiscovery(ILogger<DefaultQueryExpressionFactoryWithDiscovery> logger, Func<Type, QueryExpression?> overrides)
+        public DefaultQueryExpressionFactoryWithDiscovery(Func<Type, QueryExpression?> overrides)
         {
-            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.overrides = overrides ?? throw new ArgumentNullException(nameof(overrides));
         }
         #endregion
 
         #region methods
-        public virtual TQuery CreateQueryExpression<TQuery>()
+        public TQuery CreateQueryExpression<TQuery>()
             where TQuery : QueryExpression, new()
         {
             var expression = CreateQueryExpression(typeof(TQuery));
             if (expression is not null)
                 return (expression as TQuery)!;
 
-            if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace("Query expression factory not found in internal cache or in provided overrides, creating a factory for {query} using public parameterless constructor.", typeof(TQuery));
-
-            factories.TryAdd(typeof(TQuery), t => new TQuery());
-            return (factories[typeof(TQuery)](typeof(TQuery)) as TQuery)!;
+            return new TQuery();
         }
 
-        public virtual QueryExpression CreateQueryExpression(Type type)
+        public QueryExpression CreateQueryExpression(Type type)
         {
-            if (TryResolveQueryExpressionFactory(type, out QueryExpression? queryExpression))
+            if (TryResolveQueryExpression(type, out QueryExpression? queryExpression))
                 return queryExpression!;
 
             throw new DbExpressionConfigurationException($"Could not resolve a query expression for type '{type}'.");
         }
 
-        protected virtual bool TryResolveQueryExpressionFactory(Type type, out QueryExpression? queryExpression)
+        private bool TryResolveQueryExpression(Type type, out QueryExpression? queryExpression)
         {
             queryExpression = default;
             try
             {
-                var factory = ResolveQueryExpressionFactory(type, type);
-                if (factory is not null)
-                    queryExpression = factory(type);
-                return true;
+                queryExpression = ResolveQueryExpression(type, type);
             }
             catch
             {
                 return false;
             }
+            return queryExpression is not null;
         }
 
-        protected virtual Func<Type, QueryExpression?>? ResolveQueryExpressionFactory(Type currentType, Type requestedType)
+        private QueryExpression? ResolveQueryExpression(Type currentType, Type requestedType)
         {
             if (currentType is null)
                 return null;
 
-            if (factories.TryGetValue(currentType, out Func<Type, QueryExpression?>? factory))
-            {
-                if (currentType != requestedType)
-                    factories.TryAdd(requestedType, factory);
-                return factory;
-            }
-            
-            if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace("Query expression factory for {currentType} not found in internal cache.", currentType);
-
             var @override = overrides(currentType);
             if (@override is not null)
             {
-                factories.TryAdd(requestedType, t => overrides(currentType));
-                return t => @override;
+                return @override;
             }
-
-            if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace("Query expression factory for {currentType} was not resolved via provided overrides.", currentType);
 
             if (currentType.BaseType is null)
                 return null;
 
-            if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace("Try and resolve query expression factory for base type of {currentType}, which is {baseType}.", currentType, currentType.BaseType);
-
-            return ResolveQueryExpressionFactory(currentType.BaseType, requestedType);
+            return ResolveQueryExpression(currentType.BaseType, requestedType);
         }
         #endregion
     }

--- a/src/HatTrick.DbEx.Sql/Mapper/DefaultEntityFactoryWithFallbackConstruction.cs
+++ b/src/HatTrick.DbEx.Sql/Mapper/DefaultEntityFactoryWithFallbackConstruction.cs
@@ -16,24 +16,22 @@
 // The latest version of this file can be found at https://github.com/HatTrickLabs/db-ex
 #endregion
 
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
+using System.Reflection.Emit;
 
 namespace HatTrick.DbEx.Sql.Mapper
 {
-    public class DefaultEntityFactoryWithFallbackConstruction : IEntityFactory
+    public sealed class DefaultEntityFactoryWithFallbackConstruction : IEntityFactory
     {
         #region internals
-        private readonly ILogger<DefaultEntityFactoryWithFallbackConstruction> logger;
         private readonly Func<Type, IDbEntity?> factory;
-        private readonly ConcurrentDictionary<Type, Func<Type, IDbEntity?>> map = new();
+        private readonly ConcurrentDictionary<TypeDictionaryKey, Func<IDbEntity>> ctors = new();
         #endregion
 
         #region constructors
-        public DefaultEntityFactoryWithFallbackConstruction(ILogger<DefaultEntityFactoryWithFallbackConstruction> logger, Func<Type, IDbEntity?> factory)
+        public DefaultEntityFactoryWithFallbackConstruction(Func<Type, IDbEntity?> factory)
         {
-            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.factory = factory ?? throw new ArgumentNullException(nameof(factory));
         }
         #endregion
@@ -42,25 +40,67 @@ namespace HatTrick.DbEx.Sql.Mapper
         public TEntity CreateEntity<TEntity>()
             where TEntity : class, IDbEntity, new()
         {
-            if (map.ContainsKey(typeof(TEntity)))
-                return (map[typeof(TEntity)](typeof(TEntity)) as TEntity)!;
+#if !NET5_0_OR_GREATER
+            return factory(typeof(TEntity)) as TEntity ?? new TEntity();
+#else           
+            Type entityType = typeof(TEntity);
+            TypeDictionaryKey key = new(entityType.TypeHandle.Value);
 
-            if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace("Entity factory for {entity} not found in internal cache.", typeof(TEntity));
+            if (ctors.TryGetValue(key, out Func<IDbEntity>? ctor))
+            {
+                return (ctor!.Invoke() as TEntity)!;
+            }
 
-            var entity = factory(typeof(TEntity));
-            if (entity is not null)
+            var entity = factory(entityType);
+            if (entity is not null) 
+            {
                 return (entity as TEntity)!;
+            }
 
-            if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace("Entity factory for {entity} not found in provided factory.", typeof(TEntity));
+            DynamicMethod createEntity = new(
+                entityType.FullName!,
+                entityType,
+                null,
+                typeof(DefaultEntityFactoryWithFallbackConstruction).Module,
+                false
+            );
 
-            if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace("Entity factory not found in internal cache or in provided factory, creating a factory for {entity} using public parameterless constructor.", typeof(TEntity));
+            ILGenerator il = createEntity.GetILGenerator();
+            il.Emit(OpCodes.Newobj, typeof(TEntity).GetConstructor(Type.EmptyTypes)!);
+            il.Emit(OpCodes.Ret);
 
-            map.TryAdd(typeof(TEntity), t => new TEntity());
-            return CreateEntity<TEntity>();
+            var addCtor = System.Linq.Expressions.Expression.Lambda<Func<IDbEntity>>(System.Linq.Expressions.Expression.New(entityType)).Compile();
+            if (ctors.TryAdd(key, addCtor))
+            {
+                return (addCtor.Invoke() as TEntity)!;
+            }
+            throw new DbExpressionException($"Could not create an entity of type {typeof(TEntity)}");
+#endif
+
         }
         #endregion
+
+        #region classes
+        private readonly struct TypeDictionaryKey : IEquatable<TypeDictionaryKey>
+        {
+#region interface
+            public readonly IntPtr Ptr;
+#endregion
+
+#region constructors
+            public TypeDictionaryKey(IntPtr key) => Ptr = key;
+#endregion
+
+#region methods
+            public bool Equals(TypeDictionaryKey other)
+                => Ptr == other.Ptr;
+
+            public override int GetHashCode() => Ptr.GetHashCode();
+
+            public override bool Equals(object? obj)
+                => obj is TypeDictionaryKey other && Equals(other);
+#endregion
+        }
+#endregion
     }
 }

--- a/src/HatTrick.DbEx.Sql/Pipeline/DeleteQueryExpressionExecutionPipeline.cs
+++ b/src/HatTrick.DbEx.Sql/Pipeline/DeleteQueryExpressionExecutionPipeline.cs
@@ -95,7 +95,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             return rowsAffected;
         }
 
-        public async Task<int> ExecuteDeleteAsync(DeleteQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
+        public async ValueTask<int> ExecuteDeleteAsync(DeleteQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
         {
             if (expression is null)
                 throw new ArgumentNullException(nameof(expression));

--- a/src/HatTrick.DbEx.Sql/Pipeline/IDeleteQueryExpressionExecutionPipeline.cs
+++ b/src/HatTrick.DbEx.Sql/Pipeline/IDeleteQueryExpressionExecutionPipeline.cs
@@ -28,6 +28,6 @@ namespace HatTrick.DbEx.Sql.Pipeline
     public interface IDeleteQueryExpressionExecutionPipeline : IQueryExpressionExecutionPipeline
     {
         int ExecuteDelete(DeleteQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand);
-        Task<int> ExecuteDeleteAsync(DeleteQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct);
+        ValueTask<int> ExecuteDeleteAsync(DeleteQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Pipeline/ISelectQueryExpressionExecutionPipeline.cs
+++ b/src/HatTrick.DbEx.Sql/Pipeline/ISelectQueryExpressionExecutionPipeline.cs
@@ -62,16 +62,16 @@ namespace HatTrick.DbEx.Sql.Pipeline
         #endregion
 
         #region entity list
-        IEnumerable<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand)
+        IList<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand)
             where TEntity : class, IDbEntity, new();
 
-        IEnumerable<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity?> map)
+        IList<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new();
 
         void ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader> read)
             where TEntity : class, IDbEntity;
 
-        IEnumerable<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map)
+        IList<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new();
 
         Task ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader> read, CancellationToken ct)
@@ -80,16 +80,16 @@ namespace HatTrick.DbEx.Sql.Pipeline
         Task ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, Task> read, CancellationToken ct)
             where TEntity : class, IDbEntity;
         
-        Task<IEnumerable<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
+        Task<IList<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
             where TEntity : class, IDbEntity, new();
 
-        Task<IEnumerable<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map, CancellationToken ct)
+        Task<IList<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map, CancellationToken ct)
             where TEntity : class, IDbEntity, new();
 
-        Task<IEnumerable<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity> map, CancellationToken ct)
+        Task<IList<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity> map, CancellationToken ct)
             where TEntity : class, IDbEntity, new();
 
-        Task<IEnumerable<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken ct)
+        Task<IList<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken ct)
             where TEntity : class, IDbEntity, new();
 
         IAsyncEnumerable<TEntity> ExecuteSelectEntityListAsyncEnumerable<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
@@ -112,9 +112,9 @@ namespace HatTrick.DbEx.Sql.Pipeline
         #endregion
 
         #region value list
-        IEnumerable<T> ExecuteSelectValueList<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand);
+        IList<T> ExecuteSelectValueList<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand);
         void ExecuteSelectValueList<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<T?> read);
-        Task<IEnumerable<T>> ExecuteSelectValueListAsync<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct);
+        Task<IList<T>> ExecuteSelectValueListAsync<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct);
         Task ExecuteSelectValueListAsync<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<T?> read, CancellationToken ct);
         Task ExecuteSelectValueListAsync<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<T?, Task> read, CancellationToken ct);
         IAsyncEnumerable<T> ExecuteSelectValueListAsyncEnumerable<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct);
@@ -130,10 +130,10 @@ namespace HatTrick.DbEx.Sql.Pipeline
         #endregion
 
         #region dynamic list
-        IEnumerable<dynamic> ExecuteSelectDynamicList(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand);
+        IList<dynamic> ExecuteSelectDynamicList(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand);
         void ExecuteSelectDynamicList(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader> read);
 
-        Task<IEnumerable<dynamic>> ExecuteSelectDynamicListAsync(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct);
+        Task<IList<dynamic>> ExecuteSelectDynamicListAsync(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct);
         Task ExecuteSelectDynamicListAsync(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader> read, CancellationToken ct);
         Task ExecuteSelectDynamicListAsync(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, Task> read, CancellationToken ct);
         IAsyncEnumerable<dynamic> ExecuteSelectDynamicListAsyncEnumerable(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct);
@@ -147,9 +147,9 @@ namespace HatTrick.DbEx.Sql.Pipeline
         #endregion
 
         #region object list
-        IEnumerable<T> ExecuteSelectObjectList<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T?> map);
+        IList<T> ExecuteSelectObjectList<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T?> map);
 
-        Task<IEnumerable<T>> ExecuteSelectObjectListAsync<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T?> map, CancellationToken ct);
+        Task<IList<T>> ExecuteSelectObjectListAsync<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T?> map, CancellationToken ct);
         Task<IEnumerable<T>> ExecuteSelectObjectListAsync<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, Task<T?>> map, CancellationToken ct);
         IAsyncEnumerable<T> ExecuteSelectObjectListAsyncEnumerable<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T?> map, CancellationToken ct);
         IAsyncEnumerable<T> ExecuteSelectObjectListAsyncEnumerable<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, Task<T?>> map, CancellationToken ct);

--- a/src/HatTrick.DbEx.Sql/Pipeline/IUpdateQueryExpressionExecutionPipeline.cs
+++ b/src/HatTrick.DbEx.Sql/Pipeline/IUpdateQueryExpressionExecutionPipeline.cs
@@ -28,6 +28,6 @@ namespace HatTrick.DbEx.Sql.Pipeline
     public interface IUpdateQueryExpressionExecutionPipeline : IQueryExpressionExecutionPipeline
     {
         int ExecuteUpdate(UpdateQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand);
-        Task<int> ExecuteUpdateAsync(UpdateQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct);
+        ValueTask<int> ExecuteUpdateAsync(UpdateQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct);
     }
 }

--- a/src/HatTrick.DbEx.Sql/Pipeline/SelectQueryExpressionExecutionPipeline.cs
+++ b/src/HatTrick.DbEx.Sql/Pipeline/SelectQueryExpressionExecutionPipeline.cs
@@ -372,7 +372,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
         #endregion
 
         #region entity list
-        public IEnumerable<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand)
+        public IList<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand)
             where TEntity : class, IDbEntity, new()
         {
             var entities = new List<TEntity>();
@@ -397,7 +397,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             return entities;
         }
 
-        public IEnumerable<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity?> map)
+        public IList<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity?> map)
             where TEntity : class, IDbEntity, new()
         {
             var entities = new List<TEntity>();
@@ -456,7 +456,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             );
         }
 
-        public IEnumerable<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map)
+        public IList<TEntity> ExecuteSelectEntityList<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map)
             where TEntity : class, IDbEntity, new()
         {
             var entities = new List<TEntity>();
@@ -487,7 +487,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             return entities;
         }
 
-        public async Task<IEnumerable<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
+        public async Task<IList<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
             where TEntity : class, IDbEntity, new()
         {
             var entities = new List<TEntity>();
@@ -541,7 +541,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             ).ConfigureAwait(false);
         }
 
-        public async Task<IEnumerable<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map, CancellationToken ct)
+        public async Task<IList<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Action<ISqlFieldReader, TEntity> map, CancellationToken ct)
             where TEntity : class, IDbEntity, new()
         {
             var values = new List<TEntity>();
@@ -573,7 +573,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             return values;
         }
 
-        public async Task<IEnumerable<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity> map, CancellationToken ct)
+        public async Task<IList<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity> map, CancellationToken ct)
             where TEntity : class, IDbEntity, new()
         {
             var entities = new List<TEntity>();
@@ -633,7 +633,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             ).ConfigureAwait(false);
         }
 
-        public async Task<IEnumerable<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken ct)
+        public async Task<IList<TEntity>> ExecuteSelectEntityListAsync<TEntity>(SelectQueryExpression expression, Table<TEntity> table, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken ct)
             where TEntity : class, IDbEntity, new()
         {
             var entities = new List<TEntity>();
@@ -678,8 +678,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             ))
             {
                 var entity = entityFactory.CreateEntity<TEntity>() ?? throw new DbExpressionException($"Expected entity factory to provide an entity of type {typeof(TEntity)}.");
-                if (mapper is null)
-                    mapper = mapperFactory.CreateEntityMapper(table ?? throw new ArgumentNullException(nameof(table)));
+                mapper ??= mapperFactory.CreateEntityMapper(table ?? throw new ArgumentNullException(nameof(table)));
                 mapper.Map(row, entity);
                 yield return entity;
             }
@@ -698,8 +697,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             ))
             {
                 var entity = entityFactory.CreateEntity<TEntity>() ?? throw new DbExpressionException($"Expected entity factory to provide an entity of type {typeof(TEntity)}.");
-                if (mapper is null)
-                    mapper = mapperFactory.CreateEntityMapper(table ?? throw new ArgumentNullException(nameof(table)));
+                mapper ??= mapperFactory.CreateEntityMapper(table ?? throw new ArgumentNullException(nameof(table)));
                 map(row, entity);
                 yield return entity;
             }
@@ -717,8 +715,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
                 ct
             ))
             {
-                if (mapper is null)
-                    mapper = mapperFactory.CreateEntityMapper(table ?? throw new ArgumentNullException(nameof(table)));
+                mapper ??= mapperFactory.CreateEntityMapper(table ?? throw new ArgumentNullException(nameof(table)));
                 var entity = map(row);
                 yield return entity;
             }
@@ -737,8 +734,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             ))
             {
                 var entity = entityFactory.CreateEntity<TEntity>() ?? throw new DbExpressionException($"Expected entity factory to provide an entity of type {typeof(TEntity)}.");
-                if (mapper is null)
-                    mapper = mapperFactory.CreateEntityMapper(table ?? throw new ArgumentNullException(nameof(table)));
+                mapper ??= mapperFactory.CreateEntityMapper(table ?? throw new ArgumentNullException(nameof(table)));
                 await map(row, entity).ConfigureAwait(false);
                 yield return entity;
             }
@@ -810,7 +806,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
         #endregion
 
         #region value list
-        public IEnumerable<T> ExecuteSelectValueList<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand)
+        public IList<T> ExecuteSelectValueList<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand)
         {
             var values = new List<T>();
             ExecuteSelectQuery(
@@ -881,7 +877,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             );
         }
 
-        public async Task<IEnumerable<T>> ExecuteSelectValueListAsync<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
+        public async Task<IList<T>> ExecuteSelectValueListAsync<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
         {
             var values = new List<T>();
             await ExecuteSelectQueryAsync(
@@ -1145,7 +1141,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
         #endregion
 
         #region dynamic list
-        public IEnumerable<dynamic> ExecuteSelectDynamicList(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand)
+        public IList<dynamic> ExecuteSelectDynamicList(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand)
         {
             var values = new List<dynamic>();
             var mapper = mapperFactory.CreateExpandoObjectMapper();
@@ -1195,7 +1191,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             );
         }
 
-        public async Task<IEnumerable<dynamic>> ExecuteSelectDynamicListAsync(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
+        public async Task<IList<dynamic>> ExecuteSelectDynamicListAsync(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
         {
             var values = new List<dynamic>();
             var mapper = mapperFactory.CreateExpandoObjectMapper();
@@ -1384,7 +1380,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
         #endregion
 
         #region object list
-        public IEnumerable<T> ExecuteSelectObjectList<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T?> map)
+        public IList<T> ExecuteSelectObjectList<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T?> map)
         {
             var values = new List<T>();
             ExecuteSelectQuery(
@@ -1414,7 +1410,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             return values;
         }
 
-        public async Task<IEnumerable<T>> ExecuteSelectObjectListAsync<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T?> map, CancellationToken ct)
+        public async Task<IList<T>> ExecuteSelectObjectListAsync<T>(SelectQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, Func<ISqlFieldReader, T?> map, CancellationToken ct)
         {
             var values = new List<T>();
             await ExecuteSelectQueryAsync(

--- a/src/HatTrick.DbEx.Sql/Pipeline/UpdateQueryExpressionExecutionPipeline.cs
+++ b/src/HatTrick.DbEx.Sql/Pipeline/UpdateQueryExpressionExecutionPipeline.cs
@@ -95,7 +95,7 @@ namespace HatTrick.DbEx.Sql.Pipeline
             return rowsAffected;
         }
 
-        public async Task<int> ExecuteUpdateAsync(UpdateQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
+        public async ValueTask<int> ExecuteUpdateAsync(UpdateQueryExpression expression, ISqlConnection? connection, Action<IDbCommand>? configureCommand, CancellationToken ct)
         {
             if (expression is null)
                 throw new ArgumentNullException(nameof(expression));

--- a/src/HatTrick.DbEx.Sql/Types/IDbTypeMapFactory.cs
+++ b/src/HatTrick.DbEx.Sql/Types/IDbTypeMapFactory.cs
@@ -27,5 +27,8 @@ namespace HatTrick.DbEx.Sql.Types
         DbTypeMap<T>? FindByDbType(DbType dbType);
         DbTypeMap<T>? FindByPlatformType(T platformType);
         DbTypeMap<T>? FindByClrType(Type clrType);
+
+        bool IsUnicode(DbType dbType);
+        bool IsUnicode(T platformType);
     }
 }

--- a/src/HatTrick.DbEx.Sql/_Extensions/TypeExtensions.cs
+++ b/src/HatTrick.DbEx.Sql/_Extensions/TypeExtensions.cs
@@ -18,6 +18,7 @@
 
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace HatTrick.DbEx.Sql
 {
@@ -25,8 +26,10 @@ namespace HatTrick.DbEx.Sql
     {
         private static readonly List<Type> nonNullableTypes = new List<Type> { typeof(string), typeof(byte[]), typeof(object) };
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsNullableType(this Type t) => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsConvertibleToNullableType(this Type t) => !nonNullableTypes.Contains(t);
     }
 }

--- a/src/HatTrick.DbEx.Sql/_Shim/IsExternalInit.cs
+++ b/src/HatTrick.DbEx.Sql/_Shim/IsExternalInit.cs
@@ -1,0 +1,6 @@
+﻿#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}
+#endif

--- a/src/HatTrick.DbEx.Sql/_api/DeleteEntitiesTermination{T}.cs
+++ b/src/HatTrick.DbEx.Sql/_api/DeleteEntitiesTermination{T}.cs
@@ -61,7 +61,7 @@ namespace HatTrick.DbEx.Sql
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
         /// <returns>The number of records removed from the database.</returns>
-        Task<int> ExecuteAsync(CancellationToken cancellationToken = default);
+        ValueTask<int> ExecuteAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a DELETE query to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
@@ -69,7 +69,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql DELETE statement.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
         /// <returns>The number of records removed from the database.</returns>
-        Task<int> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
+        ValueTask<int> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a DELETE query to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
@@ -77,7 +77,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql DELETE statement and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
         /// <returns>The number of records removed from the database.</returns>
-        Task<int> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
+        ValueTask<int> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a DELETE query to delete <typeparamref name="TEntity"/> entities and return the number of records removed.
@@ -86,6 +86,6 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql DELETE statement and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the DELETE statement should be cancelled.</param>
         /// <returns>The number of records removed from the database.</returns>
-        Task<int> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
+        ValueTask<int> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
     }
 }

--- a/src/HatTrick.DbEx.Sql/_api/SelectDynamicsTermination{T}.cs
+++ b/src/HatTrick.DbEx.Sql/_api/SelectDynamicsTermination{T}.cs
@@ -37,21 +37,21 @@ namespace HatTrick.DbEx.Sql
         /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
         /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<dynamic> Execute();
+        IList<dynamic> Execute();
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<dynamic> Execute(int commandTimeout);
+        IList<dynamic> Execute(int commandTimeout);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<dynamic> Execute(ISqlConnection connection);
+        IList<dynamic> Execute(ISqlConnection connection);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
@@ -59,14 +59,14 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<dynamic> Execute(ISqlConnection connection, int commandTimeout);
+        IList<dynamic> Execute(ISqlConnection connection, int commandTimeout);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<dynamic>> ExecuteAsync(CancellationToken cancellationToken = default);
+        Task<IList<dynamic>> ExecuteAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
@@ -81,7 +81,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<dynamic>> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
+        Task<IList<dynamic>> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
@@ -97,7 +97,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<dynamic>> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
+        Task<IList<dynamic>> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
@@ -114,7 +114,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of dynamic objects retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<dynamic>> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
+        Task<IList<dynamic>> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of dynamic objects.  The member elements of the SELECT clause determine the properties of each returned dynamic object.
@@ -130,7 +130,7 @@ namespace HatTrick.DbEx.Sql
         /// </summary>
         /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="dynamic"/>.</param>
         /// <returns>A list of <typeparamref name="T"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        IEnumerable<T> Execute<T>(Func<ISqlFieldReader, T> map);
+        IList<T> Execute<T>(Func<ISqlFieldReader, T> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="dynamic"/> using the provided <paramref name="map"/> delegate.
@@ -138,7 +138,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="dynamic"/>.</param>
         /// <returns>A list of <typeparamref name="T"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        IEnumerable<T> Execute<T>(int commandTimeout, Func<ISqlFieldReader, T> map);
+        IList<T> Execute<T>(int commandTimeout, Func<ISqlFieldReader, T> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="dynamic"/> using the provided <paramref name="map"/> delegate.
@@ -146,7 +146,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="dynamic"/>.</param>
         /// <returns>A list of <typeparamref name="T"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        IEnumerable<T> Execute<T>(ISqlConnection connection, Func<ISqlFieldReader, T> map);
+        IList<T> Execute<T>(ISqlConnection connection, Func<ISqlFieldReader, T> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="dynamic"/> using the provided <paramref name="map"/> delegate.
@@ -155,7 +155,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="dynamic"/>.</param>
         /// <returns>A list of <typeparamref name="T"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        IEnumerable<T> Execute<T>(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, T> map);
+        IList<T> Execute<T>(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, T> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to manage the returned rowset.
@@ -192,7 +192,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="dynamic"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="T"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<T>> ExecuteAsync<T>(Func<ISqlFieldReader, T> map, CancellationToken cancellationToken = default);
+        Task<IList<T>> ExecuteAsync<T>(Func<ISqlFieldReader, T> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="dynamic"/> using the provided <paramref name="map"/> delegate.
@@ -209,7 +209,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="dynamic"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="T"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<T>> ExecuteAsync<T>(int commandTimeout, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken = default);
+        Task<IList<T>> ExecuteAsync<T>(int commandTimeout, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="dynamic"/> using the provided <paramref name="map"/> delegate.
@@ -227,7 +227,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="dynamic"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="T"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<T>> ExecuteAsync<T>(ISqlConnection connection, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken = default);
+        Task<IList<T>> ExecuteAsync<T>(ISqlConnection connection, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="dynamic"/> using the provided <paramref name="map"/> delegate.
@@ -246,7 +246,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">A delegate for converting the retrieved database value to a value of type <typeparamref name="dynamic"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="T"/> values retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<T>> ExecuteAsync<T>(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken = default);
+        Task<IList<T>> ExecuteAsync<T>(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, T> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each row of the returned rowset to a <typeparamref name="dynamic"/> using the provided <paramref name="map"/> delegate.

--- a/src/HatTrick.DbEx.Sql/_api/SelectEntitiesTermination{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/_api/SelectEntitiesTermination{T,U}.cs
@@ -36,21 +36,21 @@ namespace HatTrick.DbEx.Sql
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
         /// </summary>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TEntity> Execute();
+        IList<TEntity> Execute();
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
         /// </summary>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TEntity> Execute(int commandTimeout);
+        IList<TEntity> Execute(int commandTimeout);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TEntity> Execute(ISqlConnection connection);
+        IList<TEntity> Execute(ISqlConnection connection);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
@@ -58,14 +58,14 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TEntity> Execute(ISqlConnection connection, int commandTimeout);
+        IList<TEntity> Execute(ISqlConnection connection, int commandTimeout);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
         /// </summary>
         /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        IEnumerable<TEntity> Execute(Func<ISqlFieldReader, TEntity> map);
+        IList<TEntity> Execute(Func<ISqlFieldReader, TEntity> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
@@ -73,7 +73,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        IEnumerable<TEntity> Execute(int commandTimeout, Func<ISqlFieldReader, TEntity> map);
+        IList<TEntity> Execute(int commandTimeout, Func<ISqlFieldReader, TEntity> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
@@ -81,7 +81,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        IEnumerable<TEntity> Execute(ISqlConnection connection, Func<ISqlFieldReader, TEntity> map);
+        IList<TEntity> Execute(ISqlConnection connection, Func<ISqlFieldReader, TEntity> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
@@ -90,7 +90,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        IEnumerable<TEntity> Execute(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map);
+        IList<TEntity> Execute(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to manage each rowset.
@@ -127,7 +127,7 @@ namespace HatTrick.DbEx.Sql
         /// </summary>
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TEntity> Execute(Action<ISqlFieldReader, TEntity> map);
+        IList<TEntity> Execute(Action<ISqlFieldReader, TEntity> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
@@ -135,7 +135,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TEntity> Execute(int commandTimeout, Action<ISqlFieldReader, TEntity> map);
+        IList<TEntity> Execute(int commandTimeout, Action<ISqlFieldReader, TEntity> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
@@ -143,7 +143,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TEntity> Execute(ISqlConnection connection, Action<ISqlFieldReader, TEntity> map);
+        IList<TEntity> Execute(ISqlConnection connection, Action<ISqlFieldReader, TEntity> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
@@ -152,14 +152,14 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TEntity> Execute(ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map);
+        IList<TEntity> Execute(ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
@@ -174,7 +174,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
@@ -190,7 +190,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>An enumerator providing asynchronous iteration of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
@@ -207,7 +207,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TEntity"/> entities.
@@ -256,7 +256,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to a <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
@@ -273,7 +273,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to a <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
@@ -291,7 +291,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(ISqlConnection connection, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(ISqlConnection connection, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to a <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
@@ -310,7 +310,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(ISqlConnection connection, int commandTimeout, Action<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to a <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
@@ -328,7 +328,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
@@ -345,7 +345,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
@@ -363,7 +363,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(ISqlConnection connection, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(ISqlConnection connection, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
@@ -382,7 +382,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="map">A delegate for mapping each rowset to a <typeparamref name="TEntity"/> entity.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TEntity"/> entities retrieved from execution of the sql SELECT query and mapped using the provided <paramref name="map"/> delegate.</returns>
-        Task<IEnumerable<TEntity>> ExecuteAsync(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and map each rowset to a <typeparamref name="TEntity"/> entity using the provided <paramref name="map"/> delegate.
@@ -431,7 +431,7 @@ namespace HatTrick.DbEx.Sql
         /// </summary>
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        Task<IEnumerable<TEntity>> ExecuteAsync(Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
@@ -446,7 +446,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        Task<IEnumerable<TEntity>> ExecuteAsync(int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
@@ -462,7 +462,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        Task<IEnumerable<TEntity>> ExecuteAsync(ISqlConnection connection, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(ISqlConnection connection, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.
@@ -479,7 +479,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="map">The delegate to manage each rowset returned from execution of the query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
-        Task<IEnumerable<TEntity>> ExecuteAsync(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default);
+        Task<IList<TEntity>> ExecuteAsync(ISqlConnection connection, int commandTimeout, Func<ISqlFieldReader, TEntity, Task> map, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="map"/> delegate to map each rowset to an <typeparamref name="TEntity"/> entity instance created from the configured <see cref="IEntityFactory"> entity factory</see>.

--- a/src/HatTrick.DbEx.Sql/_api/SelectObjectsTermination{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/_api/SelectObjectsTermination{T,U}.cs
@@ -36,21 +36,21 @@ namespace HatTrick.DbEx.Sql
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TObject"/> Objects.
         /// </summary>
         /// <returns>A list of <typeparamref name="TObject"/> Objects retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TObject> Execute();
+        IList<TObject> Execute();
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TObject"/> Objects.
         /// </summary>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <returns>A list of <typeparamref name="TObject"/> Objects retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TObject> Execute(int commandTimeout);
+        IList<TObject> Execute(int commandTimeout);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TObject"/> Objects.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <returns>A list of <typeparamref name="TObject"/> Objects retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TObject> Execute(ISqlConnection connection);
+        IList<TObject> Execute(ISqlConnection connection);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TObject"/> Objects.
@@ -58,7 +58,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <returns>A list of <typeparamref name="TObject"/> Objects retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TObject> Execute(ISqlConnection connection, int commandTimeout);
+        IList<TObject> Execute(ISqlConnection connection, int commandTimeout);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the retrieved Object.
@@ -93,7 +93,7 @@ namespace HatTrick.DbEx.Sql
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TObject"/> Objects retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TObject>> ExecuteAsync(CancellationToken cancellationToken = default);
+        Task<IList<TObject>> ExecuteAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TObject"/> Objects.
@@ -101,7 +101,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TObject"/> Objects retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TObject>> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
+        Task<IList<TObject>> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TObject"/> Objects.
@@ -109,7 +109,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TObject"/> Objects retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TObject>> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
+        Task<IList<TObject>> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TObject"/> Objects.
@@ -118,7 +118,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TObject"/> Objects retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TObject>> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
+        Task<IList<TObject>> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TObject"/> Objects.

--- a/src/HatTrick.DbEx.Sql/_api/SelectValuesTermination{T,U}.cs
+++ b/src/HatTrick.DbEx.Sql/_api/SelectValuesTermination{T,U}.cs
@@ -36,21 +36,21 @@ namespace HatTrick.DbEx.Sql
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
         /// </summary>
         /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TValue> Execute();
+        IList<TValue> Execute();
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
         /// </summary>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TValue> Execute(int commandTimeout);
+        IList<TValue> Execute(int commandTimeout);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
         /// </summary>
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TValue> Execute(ISqlConnection connection);
+        IList<TValue> Execute(ISqlConnection connection);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
@@ -58,7 +58,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
-        IEnumerable<TValue> Execute(ISqlConnection connection, int commandTimeout);
+        IList<TValue> Execute(ISqlConnection connection, int commandTimeout);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve records and use the <paramref name="read"/> delegate to manage the retrieved value.
@@ -94,7 +94,7 @@ namespace HatTrick.DbEx.Sql
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TValue>> ExecuteAsync(CancellationToken cancellationToken = default);
+        Task<IList<TValue>> ExecuteAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
@@ -109,7 +109,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TValue>> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
+        Task<IList<TValue>> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
@@ -125,7 +125,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql SELECT query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TValue>> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
+        Task<IList<TValue>> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.
@@ -142,7 +142,7 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql SELECT query and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the SELECT statement should be cancelled.</param>
         /// <returns>A list of <typeparamref name="TValue"/> values retrieved from execution of the sql SELECT query.</returns>
-        Task<IEnumerable<TValue>> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
+        Task<IList<TValue>> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a SELECT query to retrieve a list of <typeparamref name="TValue"/> values.

--- a/src/HatTrick.DbEx.Sql/_api/UpdateEntitiesTermination{T}.cs
+++ b/src/HatTrick.DbEx.Sql/_api/UpdateEntitiesTermination{T}.cs
@@ -61,7 +61,7 @@ namespace HatTrick.DbEx.Sql
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
         /// <returns>The number of records affected in the database.</returns>
-        Task<int> ExecuteAsync(CancellationToken cancellationToken = default);
+        ValueTask<int> ExecuteAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a UPDATE query to update <typeparamref name="TEntity"/> entities and return the number of records affected.
@@ -69,14 +69,14 @@ namespace HatTrick.DbEx.Sql
         /// <param name="connection">The active database <see cref="ISqlConnection">connection</see> to use for executing the sql UPDATE statement.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
         /// <returns>The number of records affected in the database.</returns>
-        Task<int> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
+        ValueTask<int> ExecuteAsync(ISqlConnection connection, CancellationToken cancellationToken = default);
         /// <summary>
         /// Assemble and execute a UPDATE query to update <typeparamref name="TEntity"/> entities and return the number of records affected.
         /// </summary>
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql UPDATE statement and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
         /// <returns>The number of records affected in the database.</returns>
-        Task<int> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
+        ValueTask<int> ExecuteAsync(int commandTimeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Assemble and execute a UPDATE query to update <typeparamref name="TEntity"/> entities and return the number of records affected.
@@ -85,6 +85,6 @@ namespace HatTrick.DbEx.Sql
         /// <param name="commandTimeout">The wait time (in seconds) before terminating the attempt to execute the sql UPDATE statement and generating an error.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken">cancellation token</see> to propagate notification that execution of the UPDATE statement should be cancelled.</param>
         /// <returns>The number of records affected in the database.</returns>
-        Task<int> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
+        ValueTask<int> ExecuteAsync(ISqlConnection connection, int commandTimeout, CancellationToken cancellationToken = default);
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/OnAfterAssemblyEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/OnAfterAssemblyEventTests.cs
@@ -291,7 +291,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -308,7 +308,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -325,7 +325,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterAssembly(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -342,7 +342,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();
@@ -357,7 +357,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();
@@ -416,8 +416,8 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             var token = source.Token;
             var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure =>
                 configure.Events
-                    .OnAfterAssembly(_ =>source.Cancel())
-                    .OnBeforeCommand(async _ => await Task.Run(() => throw new NotImplementedException()))
+                    .OnAfterAssembly(_ => source.Cancel())
+                    .OnBeforeCommand(async _ => { await Task.Delay(1); throw new NotImplementedException(); })
             );
             var task = db.SelectOne<Person>().From(dbo.Person).ExecuteAsync(token);
 

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/OnAfterCompleteEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/OnAfterCompleteEventTests.cs
@@ -291,7 +291,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -308,7 +308,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -325,7 +325,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterComplete(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -342,7 +342,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();
@@ -357,7 +357,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/OnBeforeCommandEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/OnBeforeCommandEventTests.cs
@@ -291,7 +291,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -308,7 +308,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -325,7 +325,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeCommand(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -342,7 +342,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();
@@ -357,7 +357,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/OnBeforeStartEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/OnBeforeStartEventTests.cs
@@ -291,7 +291,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -308,7 +308,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -325,7 +325,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStart(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -342,7 +342,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();
@@ -357,7 +357,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Delete/OnAfterDeleteAssemblyEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Delete/OnAfterDeleteAssemblyEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteAssembly(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Delete().From(dbo.PersonAddress).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Delete().From(dbo.PersonAddress).ExecuteAsync();
@@ -284,7 +284,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Delete/OnAfterDeleteCommandEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Delete/OnAfterDeleteCommandEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteCommand(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Delete().From(dbo.PersonAddress).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Delete().From(dbo.PersonAddress).ExecuteAsync();
@@ -284,7 +284,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Delete/OnAfterDeleteCompleteEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Delete/OnAfterDeleteCompleteEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteComplete(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Delete().From(dbo.PersonAddress).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterDeleteComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Delete().From(dbo.PersonAddress).ExecuteAsync();
@@ -284,7 +284,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Delete/OnBeforeDeleteCommandEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Delete/OnBeforeDeleteCommandEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteCommand(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Delete().From(dbo.PersonAddress).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Delete().From(dbo.PersonAddress).ExecuteAsync();
@@ -284,7 +284,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
 
         [Theory]
@@ -305,7 +305,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Delete/OnBeforeDeleteStartEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Delete/OnBeforeDeleteStartEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteStart(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Delete().From(dbo.PersonAddress).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Delete().From(dbo.PersonAddress).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeDeleteStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Delete().From(dbo.PersonAddress).ExecuteAsync();
@@ -284,7 +284,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
 
         [Theory]
@@ -305,7 +305,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Insert/OnAfterInsertAssemblyEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Insert/OnAfterInsertAssemblyEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertAssembly(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Insert/OnAfterInsertCommandEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Insert/OnAfterInsertCommandEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertCommand(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Insert/OnAfterInsertCompleteEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Insert/OnAfterInsertCompleteEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertComplete(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterInsertComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Insert/OnBeforeInsertCommandEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Insert/OnBeforeInsertCommandEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertCommand(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Insert(new Address { Line1 = "123 Main St", City = "Nowhere", State = "XX", Zip = "00000" }).Into(dbo.Address).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Insert/OnBeforeInsertStartEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Insert/OnBeforeInsertStartEventTests.cs
@@ -180,7 +180,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
             var person = new Person { FirstName = "xxx", LastName = "YYY", GenderType = GenderType.Female, RegistrationDate = DateTimeOffset.UtcNow };
 
             //when
@@ -198,7 +198,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
             var person = new Person { FirstName = "xxx", LastName = "YYY", GenderType = GenderType.Female, RegistrationDate = DateTimeOffset.UtcNow };
 
             //when
@@ -216,7 +216,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertStart(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
             var person = new Person { FirstName = "xxx", LastName = "YYY", GenderType = GenderType.Female, RegistrationDate = DateTimeOffset.UtcNow };
 
             //when
@@ -234,7 +234,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
             var person = new Person { FirstName = "xxx", LastName = "YYY", GenderType = GenderType.Female, RegistrationDate = DateTimeOffset.UtcNow };
 
             //when
@@ -250,7 +250,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeInsertStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
             var person = new Person { FirstName = "xxx", LastName = "YYY", GenderType = GenderType.Female, RegistrationDate = DateTimeOffset.UtcNow };
 
             //when

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Select/OnAfterSelectAssemblyEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Select/OnAfterSelectAssemblyEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectAssembly(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Select/OnAfterSelectCommandEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Select/OnAfterSelectCommandEventTests.cs
@@ -291,7 +291,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -308,7 +308,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -325,7 +325,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectCommand(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -342,7 +342,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();
@@ -357,7 +357,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Select/OnAfterSelectCompleteEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Select/OnAfterSelectCompleteEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectComplete(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterSelectComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Select/OnBeforeSelectCommandEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Select/OnBeforeSelectCommandEventTests.cs
@@ -291,7 +291,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -308,7 +308,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -325,7 +325,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectCommand(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -342,7 +342,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();
@@ -357,7 +357,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Select/OnBeforeSelectStartEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Select/OnBeforeSelectStartEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectStart(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.SelectOne<Person>().From(dbo.Person).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeSelectStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.SelectOne<Person>().From(dbo.Person).ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_StoredProcedure/OnAfterStoredProcedureAssemblyEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_StoredProcedure/OnAfterStoredProcedureAssemblyEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureAssembly(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_StoredProcedure/OnAfterStoredProcedureCompleteEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_StoredProcedure/OnAfterStoredProcedureCompleteEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureComplete(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterStoredProcedureComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_StoredProcedure/OnBeforeStoredProcedureStartEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_StoredProcedure/OnBeforeStoredProcedureStartEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStoredProcedureStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStoredProcedureStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStoredProcedureStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStoredProcedureStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStoredProcedureStart(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStoredProcedureStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStoredProcedureStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStoredProcedureStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStoredProcedureStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeStoredProcedureStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.sp.dbo.SelectPersonId_As_ScalarValue_With_Input(1).GetValue<int>().ExecuteAsync();

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Update/OnAfterUpdateAssemblyEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Update/OnAfterUpdateAssemblyEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateAssembly(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateAssembly(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateAssembly(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateAssembly(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).ExecuteAsync();
@@ -284,7 +284,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Update/OnAfterUpdateCommandEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Update/OnAfterUpdateCommandEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateCommand(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).ExecuteAsync();
@@ -284,7 +284,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Update/OnAfterUpdateCompleteEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Update/OnAfterUpdateCompleteEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateComplete(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateComplete(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateComplete(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateComplete(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnAfterUpdateComplete(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).ExecuteAsync();
@@ -284,7 +284,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Update/OnBeforeUpdateCommandEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Update/OnBeforeUpdateCommandEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateCommand(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateCommand(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateCommand(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateCommand(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateCommand(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).ExecuteAsync();
@@ -284,7 +284,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
 
         [Theory]
@@ -305,7 +305,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Update/OnBeforeUpdateStartEventTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/Events/_Update/OnBeforeUpdateStartEventTests.cs
@@ -171,7 +171,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -188,7 +188,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -205,7 +205,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateStart(async _ => await Task.Run(() => actionExecuted = true), p => false));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => false));
 
             //when
             db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).Execute();
@@ -222,7 +222,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateStart(async _ => await Task.Run(() => actionExecuted = true)));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateStart(async _ => { actionExecuted = true; await Task.Delay(1); }));
 
             //when
             await db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).ExecuteAsync();
@@ -237,7 +237,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
         {
             //given
             bool actionExecuted = false;
-            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateStart(async _ => await Task.Run(() => actionExecuted = true), p => true));
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, configure => configure.Events.OnBeforeUpdateStart(async _ => { actionExecuted = true; await Task.Delay(1); }, p => true));
 
             //when
             await db.Update(dbo.Person.FirstName.Set("foo")).From(dbo.Person).Where(dbo.Person.Id == 0).ExecuteAsync();
@@ -284,7 +284,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration.Events
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
 
             //then
-            task.Status.Should().Be(TaskStatus.Canceled);
+            task.AsTask().Status.Should().Be(TaskStatus.Canceled);
         }
     }
 }

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/HatTrick.DbEx.MsSql.Test.Integration.csproj
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/HatTrick.DbEx.MsSql.Test.Integration.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks Condition="Exists('$(TARGET_NET_FRAMEWORK)')">net48</TargetFrameworks>
-		<TargetFrameworks Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">net7.0</TargetFrameworks>
+		<TargetFrameworks Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">net6.0;net7.0</TargetFrameworks>
 		<LangVersion Condition="Exists('$(TARGET_NET_FRAMEWORK)')">7.3</LangVersion>
 		<LangVersion Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">latest</LangVersion>
 		<Nullable>enable</Nullable>

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/_SelectOne/SelectOneTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/_SelectOne/SelectOneTests.cs
@@ -40,6 +40,25 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
         [Theory]
         [MsSqlVersions.AllVersions]
         [Trait("Operation", "WHERE")]
+        public void Does_a_non_existent_person_record_select_and_return_null_successfully(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            var exp = db.SelectOne<Person>()
+                .From(dbo.Person)
+                .Where(dbo.Person.Id == -1);
+
+            //when               
+            Person? person = exp.Execute();
+
+            //then
+            person.Should().BeNull();
+        }
+
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        [Trait("Operation", "WHERE")]
         public async Task Can_a_person_record_select_async_successfully(int version)
         {
             //given

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/Assembler/AppenderTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/Assembler/AppenderTests.cs
@@ -1,0 +1,116 @@
+﻿using DbEx.DataService;
+using FluentAssertions;
+using HatTrick.DbEx.MsSql.Configuration;
+using HatTrick.DbEx.Sql.Assembler;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace HatTrick.DbEx.MsSql.Test.Unit.Assembler
+{
+    public class AppenderTests : TestBase
+    {
+        private static string[] contentSegments = new string[]
+        {
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sed vulputate odio ut enim blandit volutpat maecenas. Lacus laoreet "
+            + "non curabitur gravida arcu ac tortor dignissim convallis. Ac turpis egestas maecenas pharetra convallis posuere morbi. Quisque sagittis purus sit amet volutpat consequat. Eu sem integer vitae justo. "
+            + "Tellus in hac habitasse platea dictumst vestibulum. Sed risus pretium quam vulputate dignissim. Massa id neque aliquam vestibulum morbi blandit cursus risus at. Vel eros donec ac odio tempor orci dapibus. "
+            + "Semper viverra nam libero justo laoreet sit. Etiam tempor orci eu lobortis. Arcu odio ut sem nulla pharetra. Consectetur lorem donec massa sapien faucibus et molestie ac feugiat. Habitant morbi tristique ",
+            "senectus et. Aliquam malesuada bibendum arcu vitae. Dolor purus non enim praesent elementum facilisis leo.  Interdum varius sit amet mattis vulputate. Gravida rutrum quisque non tellus. In pellentesque massa "
+            + "placerat duis ultricies. Sit amet nisl purus in mollis nunc. In est ante in nibh mauris cursus mattis molestie. Sollicitudin tempor id eu nisl nunc mi. Lacus luctus accumsan tortor posuere ac. Ut venenatis "
+            + "tellus in metus vulputate eu. Auctor urna nunc id cursus metus aliquam. Nisl nunc mi ipsum faucibus vitae aliquet nec. Ultrices neque ornare aenean euismod elementum. Proin libero nunc consequat interdum varius. "
+            + "Dignissim cras tincidunt lobortis feugiat. At augue eget arcu dictum varius duis at consectetur. Maecenas sed enim ut sem. Potenti nullam ac tortor vitae purus faucibus ornare suspendisse.  At imperdiet dui ",
+            "accumsan sit amet. Gravida dictum fusce ut placerat. Volutpat sed cras ornare arcu dui. At ultrices mi tempus imperdiet nulla malesuada pellentesque elit eget. In massa tempor nec feugiat. Fames ac turpis "
+            + "egestas integer eget aliquet nibh. Augue neque gravida in fermentum et sollicitudin ac orci phasellus. Non tellus orci ac auctor. Morbi non arcu risus quis. Condimentum lacinia quis vel eros. Velit "
+            + "scelerisque in dictum non consectetur a erat. Semper auctor neque vitae tempus quam pellentesque nec nam aliquam. Facilisis volutpat est velit egestas dui id ornare. Nunc congue nisi vitae suscipit tellus "
+            + "mauris a. Risus pretium quam vulputate dignissim suspendisse. Congue nisi vitae suscipit tellus mauris a. Faucibus ornare suspendisse sed nisi lacus. Mi quis hendrerit dolor magna.  Et leo duis ut diam ",
+            "quam nulla porttitor massa. Donec ac odio tempor orci. Dolor purus non enim praesent elementum facilisis leo vel. Nullam ac tortor vitae purus faucibus ornare. Pretium aenean pharetra magna ac placerat "
+            + "vestibulum. Lacus luctus accumsan tortor posuere ac ut consequat semper viverra. Turpis in eu mi bibendum neque egestas congue. In arcu cursus euismod quis viverra nibh cras. Vestibulum mattis ullamcorper "
+            + "velit sed ullamcorper. Ullamcorper eget nulla facilisi etiam. Viverra orci sagittis eu volutpat odio. Consectetur adipiscing elit ut aliquam purus sit amet luctus venenatis. Vitae congue eu consequat ac. ",
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sed vulputate odio ut enim blandit volutpat maecenas. Lacus laoreet "
+            + "non curabitur gravida arcu ac tortor dignissim convallis. Ac turpis egestas maecenas pharetra convallis posuere morbi. Quisque sagittis purus sit amet volutpat consequat. Eu sem integer vitae justo. "
+            + "Tellus in hac habitasse platea dictumst vestibulum. Sed risus pretium quam vulputate dignissim. Massa id neque aliquam vestibulum morbi blandit cursus risus at. Vel eros donec ac odio tempor orci dapibus. "
+            + "Semper viverra nam libero justo laoreet sit. Etiam tempor orci eu lobortis. Arcu odio ut sem nulla pharetra. Consectetur lorem donec massa sapien faucibus et molestie ac feugiat. Habitant morbi tristique ",
+            "senectus et. Aliquam malesuada bibendum arcu vitae. Dolor purus non enim praesent elementum facilisis leo.  Interdum varius sit amet mattis vulputate. Gravida rutrum quisque non tellus. In pellentesque massa "
+            + "placerat duis ultricies. Sit amet nisl purus in mollis nunc. In est ante in nibh mauris cursus mattis molestie. Sollicitudin tempor id eu nisl nunc mi. Lacus luctus accumsan tortor posuere ac. Ut venenatis "
+            + "tellus in metus vulputate eu. Auctor urna nunc id cursus metus aliquam. Nisl nunc mi ipsum faucibus vitae aliquet nec. Ultrices neque ornare aenean euismod elementum. Proin libero nunc consequat interdum varius. "
+            + "Dignissim cras tincidunt lobortis feugiat. At augue eget arcu dictum varius duis at consectetur. Maecenas sed enim ut sem. Potenti nullam ac tortor vitae purus faucibus ornare suspendisse.  At imperdiet dui ",
+            "accumsan sit amet. Gravida dictum fusce ut placerat. Volutpat sed cras ornare arcu dui. At ultrices mi tempus imperdiet nulla malesuada pellentesque elit eget. In massa tempor nec feugiat. Fames ac turpis "
+            + "egestas integer eget aliquet nibh. Augue neque gravida in fermentum et sollicitudin ac orci phasellus. Non tellus orci ac auctor. Morbi non arcu risus quis. Condimentum lacinia quis vel eros. Velit "
+            + "scelerisque in dictum non consectetur a erat. Semper auctor neque vitae tempus quam pellentesque nec nam aliquam. Facilisis volutpat est velit egestas dui id ornare. Nunc congue nisi vitae suscipit tellus "
+            + "mauris a. Risus pretium quam vulputate dignissim suspendisse. Congue nisi vitae suscipit tellus mauris a. Faucibus ornare suspendisse sed nisi lacus. Mi quis hendrerit dolor magna.  Et leo duis ut diam ",
+            "quam nulla porttitor massa. Donec ac odio tempor orci. Dolor purus non enim praesent elementum facilisis leo vel. Nullam ac tortor vitae purus faucibus ornare. Pretium aenean pharetra magna ac placerat "
+            + "vestibulum. Lacus luctus accumsan tortor posuere ac ut consequat semper viverra. Turpis in eu mi bibendum neque egestas congue. In arcu cursus euismod quis viverra nibh cras. Vestibulum mattis ullamcorper "
+            + "velit sed ullamcorper. Ullamcorper eget nulla facilisi etiam. Viverra orci sagittis eu volutpat odio. Consectetur adipiscing elit ut aliquam purus sit amet luctus venenatis. Vitae congue eu consequat ac."
+        };
+
+        private static string GetJoinedContent(int segmentCount)
+        {
+            var output = string.Empty;
+            for (var i = 0; i < segmentCount; i++)
+            {
+                output += contentSegments[i];
+            }
+            return output;
+        } 
+        
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Can_an_appender_build_correct_output(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            var appender = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IAppender>();
+
+            for (var i = 0; i < contentSegments.Length; i++)
+            {
+                appender.Write(contentSegments[i]);
+            }
+
+            var appended = appender.ToString();
+
+            //then
+
+            appended.Should().Be(GetJoinedContent(contentSegments.Length));
+        }
+        
+        [Theory]
+        [MsSqlVersions.AllVersions]
+        public void Can_multiple_appenders_buid_correct_output(int version)
+        {
+            //given
+            var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
+
+            //when
+            var appender1 = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IAppender>();
+            var appender2 = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IAppender>();
+            var appender3 = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IAppender>();
+            
+            for (var i = 0; i < contentSegments.Length; i++)
+            {
+                appender1.Write(contentSegments[i]);
+            }
+            var appended1 = appender1.ToString();
+            appender1.Dispose();
+            
+            for (var i = 0; i < contentSegments.Length; i++)
+            {
+                appender2.Write(contentSegments[i]);
+            }
+            var appended2 = appender2.ToString();
+            appender2.Dispose();
+            
+            for (var i = 0; i < contentSegments.Length; i++)
+            {
+                appender3.Write(contentSegments[i]);
+            }
+            var appended3 = appender3.ToString();
+            appender3.Dispose();
+            
+            //then
+            appended1.Should().Be(appended2);
+            appended2.Should().Be(appended3);
+        }
+    }
+}

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/Assembler/ParameterBuilderTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/Assembler/ParameterBuilderTests.cs
@@ -49,7 +49,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Assembler
             //then
             newParameter.Should().NotBe(parameter);
         }
-
+        
         [Theory]
         [MsSqlVersions.AllVersions]
         public void Does_adding_a_long_and_int_parameters_with_samve_value_result_in_new_parameter(int version)

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/Configuration/AppenderConfigurationTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/Configuration/AppenderConfigurationTests.cs
@@ -147,12 +147,12 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Configuration
         {
             public AppenderIndentation Indentation { get; set; } = new(null!);
 
-            public IAppender If(bool append, params Action<Appender>[] values)
+            public IAppender If(bool append, params Action<IAppender>[] values)
             {
                 throw new NotImplementedException();
             }
 
-            public IAppender IfNotEmpty(string? test, params Action<Appender>[] values)
+            public IAppender IfNotEmpty(string? test, params Action<IAppender>[] values)
             {
                 throw new NotImplementedException();
             }
@@ -175,6 +175,10 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Configuration
             public IAppender Write(char value)
             {
                 throw new NotImplementedException();
+            }
+
+            public void Dispose()
+            {
             }
         }
     }

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/Configuration/EntityFactoryConfigurationTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/Configuration/EntityFactoryConfigurationTests.cs
@@ -192,7 +192,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Configuration
 
         [Theory]
         [MsSqlVersions.AllVersions]
-        public void Does_configuration_of_a_entity_creation_factory_using_service_serviceProvider_and_new_instance_from_factory_resolve_as_transient(int version)
+        public void Does_configuration_of_a_entity_creation_factory_using_service_provider_and_new_instance_from_factory_resolve_as_transient(int version)
         {
             //given
             var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version, builder => builder.Entities.Creation.Use(sp => new NoOpEntityFactory()));
@@ -202,7 +202,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Configuration
             var a2 = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IEntityFactory>();
 
             //then
-            a1.Should().NotBe(a2);
+            a1.Should().Be(a2);
         }
 
         [Theory]

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/HatTrick.DbEx.MsSql.Test.Unit.csproj
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/HatTrick.DbEx.MsSql.Test.Unit.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks Condition="Exists('$(TARGET_NET_FRAMEWORK)')">net48</TargetFrameworks>
-		<TargetFrameworks Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">net7.0</TargetFrameworks>
+		<TargetFrameworks Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">net6.0;net7.0</TargetFrameworks>
 		<LangVersion Condition="Exists('$(TARGET_NET_FRAMEWORK)')">7.3</LangVersion>
 		<LangVersion Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">latest</LangVersion>
 		<Nullable>enable</Nullable>

--- a/test/HatTrick.DbEx.MsSql.Test/Generated/MsSqlDbAlt/DbExDataService.generated.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/Generated/MsSqlDbAlt/DbExDataService.generated.cs
@@ -1154,7 +1154,7 @@ namespace DbExAlt.DataService
         private static readonly SqlDatabaseMetadataProvider _metadata = new SqlDatabaseMetadataProvider(new MsSqlDbAltSqlDatabaseMetadata("MsSqlDbAlt"));
         private static readonly MsSqlFunctionExpressionBuilder _fx = new MsSqlFunctionExpressionBuilder();
         private static readonly List<SchemaExpression> _schemas = new List<SchemaExpression>();
-        private static readonly Dictionary<Type, Table> _entityTypeToTableMap = new Dictionary<Type, Table>();
+        private static readonly Dictionary<EntityTypeKey, Table> _entityTypeToTableMap = new Dictionary<EntityTypeKey, Table>();
         private readonly IQueryExpressionBuilderFactory<MsSqlDbAlt> _queryExpressionBuilderFactory;
         private readonly IDbConnectionFactory _connectionFactory;
         private MsSqlDbAltStoredProcedures? _sp;
@@ -1173,29 +1173,29 @@ namespace DbExAlt.DataService
             var dboAltSchema = new _dboAltDataService.dboAltSchemaExpression(1);
             _schemas.Add(dboAltSchema);
             _dboAltDataService.dboAlt.UseSchema(dboAltSchema);
-            _entityTypeToTableMap.Add(typeof(dboAltData.AccessAuditLog), dboAltSchema.AccessAuditLog);
-            _entityTypeToTableMap.Add(typeof(dboAltData.Address), dboAltSchema.Address);
-            _entityTypeToTableMap.Add(typeof(dboAltData.PersonAlt), dboAltSchema.PersonAlt);
-            _entityTypeToTableMap.Add(typeof(dboAltData.Person_Address), dboAltSchema.Person_Address);
-            _entityTypeToTableMap.Add(typeof(dboAltData.Product), dboAltSchema.Product);
-            _entityTypeToTableMap.Add(typeof(dboAltData.Purchase), dboAltSchema.Purchase);
-            _entityTypeToTableMap.Add(typeof(dboAltData.PurchaseLine), dboAltSchema.PurchaseLine);
-            _entityTypeToTableMap.Add(typeof(dboAltData.PersonTotalPurchasesView), dboAltSchema.PersonTotalPurchasesView);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboAltData.AccessAuditLog).TypeHandle.Value), dboAltSchema.AccessAuditLog);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboAltData.Address).TypeHandle.Value), dboAltSchema.Address);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboAltData.PersonAlt).TypeHandle.Value), dboAltSchema.PersonAlt);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboAltData.Person_Address).TypeHandle.Value), dboAltSchema.Person_Address);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboAltData.Product).TypeHandle.Value), dboAltSchema.Product);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboAltData.Purchase).TypeHandle.Value), dboAltSchema.Purchase);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboAltData.PurchaseLine).TypeHandle.Value), dboAltSchema.PurchaseLine);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboAltData.PersonTotalPurchasesView).TypeHandle.Value), dboAltSchema.PersonTotalPurchasesView);
 
             var secSchema = new _secDataService.secSchemaExpression(114);
             _schemas.Add(secSchema);
             _secDataService.sec.UseSchema(secSchema);
-            _entityTypeToTableMap.Add(typeof(secData.Person), secSchema.Person);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(secData.Person).TypeHandle.Value), secSchema.Person);
 
             var unit_testSchema = new _unit_testDataService.unit_testSchemaExpression(120);
             _schemas.Add(unit_testSchema);
             _unit_testDataService.unit_test.UseSchema(unit_testSchema);
-            _entityTypeToTableMap.Add(typeof(unit_testData.alias), unit_testSchema.alias);
-            _entityTypeToTableMap.Add(typeof(unit_testData.entity), unit_testSchema.entity);
-            _entityTypeToTableMap.Add(typeof(unit_testData.ExpressionElementType), unit_testSchema.ExpressionElementType);
-            _entityTypeToTableMap.Add(typeof(unit_testData.identifier), unit_testSchema.identifier);
-            _entityTypeToTableMap.Add(typeof(unit_testData.name), unit_testSchema.name);
-            _entityTypeToTableMap.Add(typeof(unit_testData.schema), unit_testSchema.schema);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.alias).TypeHandle.Value), unit_testSchema.alias);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.entity).TypeHandle.Value), unit_testSchema.entity);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.ExpressionElementType).TypeHandle.Value), unit_testSchema.ExpressionElementType);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.identifier).TypeHandle.Value), unit_testSchema.identifier);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.name).TypeHandle.Value), unit_testSchema.name);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.schema).TypeHandle.Value), unit_testSchema.schema);
 
         }
 
@@ -2303,9 +2303,9 @@ namespace DbExAlt.DataService
         protected virtual Table<TEntity> GetTable<TEntity>()
             where TEntity : class, IDbEntity
         {
-            if (!_entityTypeToTableMap.ContainsKey(typeof(TEntity)))
+            if (!_entityTypeToTableMap.TryGetValue(new EntityTypeKey(typeof(TEntity).TypeHandle.Value), out var table))
                 throw new DbExpressionException($"Entity type {typeof(TEntity)} is not known.");
-            return _entityTypeToTableMap[typeof(TEntity)] as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {typeof(TEntity)}.");
+            return table as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {typeof(TEntity)}.");
         }
         #endregion
 
@@ -2728,6 +2728,17 @@ namespace DbExAlt.DataService
         }
 
         #endregion
+        #endregion
+
+        #region classes
+        private readonly struct EntityTypeKey : IEquatable<EntityTypeKey>
+        {
+            public readonly IntPtr Ptr;
+            public EntityTypeKey(IntPtr key) => Ptr = key;
+            public bool Equals(EntityTypeKey other) => Ptr == other.Ptr;
+            public override int GetHashCode() => Ptr.GetHashCode();
+            public override bool Equals(object? obj) => obj is EntityTypeKey other && Equals(other);
+        }
         #endregion
     }
     #endregion

--- a/test/HatTrick.DbEx.MsSql.Test/Generated/v2016MsSqlDb/DbExDataService.generated.cs
+++ b/test/HatTrick.DbEx.MsSql.Test/Generated/v2016MsSqlDb/DbExDataService.generated.cs
@@ -1160,7 +1160,7 @@ namespace v2016DbEx.DataService
         private static readonly SqlDatabaseMetadataProvider _metadata = new SqlDatabaseMetadataProvider(new v2016MsSqlDbSqlDatabaseMetadata("v2016MsSqlDb"));
         private static readonly MsSqlFunctionExpressionBuilder _fx = new MsSqlFunctionExpressionBuilder();
         private static readonly List<SchemaExpression> _schemas = new List<SchemaExpression>();
-        private static readonly Dictionary<Type, Table> _entityTypeToTableMap = new Dictionary<Type, Table>();
+        private static readonly Dictionary<EntityTypeKey, Table> _entityTypeToTableMap = new Dictionary<EntityTypeKey, Table>();
         private readonly IQueryExpressionBuilderFactory<v2016MsSqlDb> _queryExpressionBuilderFactory;
         private readonly IDbConnectionFactory _connectionFactory;
         private v2016MsSqlDbStoredProcedures? _sp;
@@ -1179,29 +1179,29 @@ namespace v2016DbEx.DataService
             var dboSchema = new _dboDataService.dboSchemaExpression(1);
             _schemas.Add(dboSchema);
             _dboDataService.dbo.UseSchema(dboSchema);
-            _entityTypeToTableMap.Add(typeof(dboData.AccessAuditLog), dboSchema.AccessAuditLog);
-            _entityTypeToTableMap.Add(typeof(dboData.Address), dboSchema.Address);
-            _entityTypeToTableMap.Add(typeof(dboData.Person), dboSchema.Person);
-            _entityTypeToTableMap.Add(typeof(dboData.PersonAddress), dboSchema.PersonAddress);
-            _entityTypeToTableMap.Add(typeof(dboData.Product), dboSchema.Product);
-            _entityTypeToTableMap.Add(typeof(dboData.Purchase), dboSchema.Purchase);
-            _entityTypeToTableMap.Add(typeof(dboData.PurchaseLine), dboSchema.PurchaseLine);
-            _entityTypeToTableMap.Add(typeof(dboData.PersonTotalPurchasesView), dboSchema.PersonTotalPurchasesView);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.AccessAuditLog).TypeHandle.Value), dboSchema.AccessAuditLog);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Address).TypeHandle.Value), dboSchema.Address);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Person).TypeHandle.Value), dboSchema.Person);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.PersonAddress).TypeHandle.Value), dboSchema.PersonAddress);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Product).TypeHandle.Value), dboSchema.Product);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.Purchase).TypeHandle.Value), dboSchema.Purchase);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.PurchaseLine).TypeHandle.Value), dboSchema.PurchaseLine);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(dboData.PersonTotalPurchasesView).TypeHandle.Value), dboSchema.PersonTotalPurchasesView);
 
             var secSchema = new _secDataService.secSchemaExpression(114);
             _schemas.Add(secSchema);
             _secDataService.sec.UseSchema(secSchema);
-            _entityTypeToTableMap.Add(typeof(secData.Person), secSchema.Person);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(secData.Person).TypeHandle.Value), secSchema.Person);
 
             var unit_testSchema = new _unit_testDataService.unit_testSchemaExpression(120);
             _schemas.Add(unit_testSchema);
             _unit_testDataService.unit_test.UseSchema(unit_testSchema);
-            _entityTypeToTableMap.Add(typeof(unit_testData.alias), unit_testSchema.alias);
-            _entityTypeToTableMap.Add(typeof(unit_testData.entity), unit_testSchema.entity);
-            _entityTypeToTableMap.Add(typeof(unit_testData.ExpressionElementType), unit_testSchema.ExpressionElementType);
-            _entityTypeToTableMap.Add(typeof(unit_testData.identifier), unit_testSchema.identifier);
-            _entityTypeToTableMap.Add(typeof(unit_testData.name), unit_testSchema.name);
-            _entityTypeToTableMap.Add(typeof(unit_testData.schema), unit_testSchema.schema);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.alias).TypeHandle.Value), unit_testSchema.alias);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.entity).TypeHandle.Value), unit_testSchema.entity);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.ExpressionElementType).TypeHandle.Value), unit_testSchema.ExpressionElementType);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.identifier).TypeHandle.Value), unit_testSchema.identifier);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.name).TypeHandle.Value), unit_testSchema.name);
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof(unit_testData.schema).TypeHandle.Value), unit_testSchema.schema);
 
         }
 
@@ -2313,9 +2313,9 @@ namespace v2016DbEx.DataService
         protected virtual Table<TEntity> GetTable<TEntity>()
             where TEntity : class, IDbEntity
         {
-            if (!_entityTypeToTableMap.ContainsKey(typeof(TEntity)))
+            if (!_entityTypeToTableMap.TryGetValue(new EntityTypeKey(typeof(TEntity).TypeHandle.Value), out var table))
                 throw new DbExpressionException($"Entity type {typeof(TEntity)} is not known.");
-            return _entityTypeToTableMap[typeof(TEntity)] as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {typeof(TEntity)}.");
+            return table as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {typeof(TEntity)}.");
         }
         #endregion
 
@@ -2738,6 +2738,17 @@ namespace v2016DbEx.DataService
         }
 
         #endregion
+        #endregion
+
+        #region classes
+        private readonly struct EntityTypeKey : IEquatable<EntityTypeKey>
+        {
+            public readonly IntPtr Ptr;
+            public EntityTypeKey(IntPtr key) => Ptr = key;
+            public bool Equals(EntityTypeKey other) => Ptr == other.Ptr;
+            public override int GetHashCode() => Ptr.GetHashCode();
+            public override bool Equals(object? obj) => obj is EntityTypeKey other && Equals(other);
+        }
         #endregion
     }
     #endregion

--- a/test/HatTrick.DbEx.MsSql.Test/HatTrick.DbEx.MsSql.Test.csproj
+++ b/test/HatTrick.DbEx.MsSql.Test/HatTrick.DbEx.MsSql.Test.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks Condition="Exists('$(TARGET_NET_FRAMEWORK)')">net48</TargetFrameworks>
-		<TargetFrameworks Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">net7.0</TargetFrameworks>
+		<TargetFrameworks Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">net6.0;net7.0</TargetFrameworks>
 		<LangVersion Condition="Exists('$(TARGET_NET_FRAMEWORK)')">7.3</LangVersion>
 		<LangVersion Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">latest</LangVersion>
 		<Nullable>enable</Nullable>

--- a/test/HatTrick.DbEx.Sql.Test/Assembler/AppenderTests.cs
+++ b/test/HatTrick.DbEx.Sql.Test/Assembler/AppenderTests.cs
@@ -107,7 +107,7 @@ namespace HatTrick.DbEx.Sql.Test.Assembler
             var appender = new Appender();
 
             //when
-            appender.IfNotEmpty(null!, a => a.Write("hello"));
+            appender.IfNotEmpty(null, a => a.Write("hello"));
 
             //then
             Assert.Empty(appender.ToString());

--- a/test/HatTrick.DbEx.Sql.Test/HatTrick.DbEx.Sql.Test.csproj
+++ b/test/HatTrick.DbEx.Sql.Test/HatTrick.DbEx.Sql.Test.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks Condition="Exists('$(TARGET_NET_FRAMEWORK)')">net48</TargetFrameworks>
-		<TargetFrameworks Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">net7.0</TargetFrameworks>
+		<TargetFrameworks Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">net6.0;net7.0</TargetFrameworks>
 		<LangVersion Condition="Exists('$(TARGET_NET_FRAMEWORK)')">7.3</LangVersion>
 		<LangVersion Condition="!Exists('$(TARGET_NET_FRAMEWORK)')">latest</LangVersion>
 		<Nullable>enable</Nullable>

--- a/tools/HatTrick.DbEx.Tools/Model/NullableLanguageFeatureModel.cs
+++ b/tools/HatTrick.DbEx.Tools/Model/NullableLanguageFeatureModel.cs
@@ -23,7 +23,7 @@ namespace HatTrick.DbEx.Tools.Model
     {
         private NullableFeatureTypeCode? _nullableFeature;
         public bool IsFeatureEnabled => _nullableFeature == NullableFeatureTypeCode.Enable;
-        public string Directive => _nullableFeature is not null ? $"#nullable {_nullableFeature.Value.ToString().ToLower()}" : string.Empty;
+        public string Directive => _nullableFeature == NullableFeatureTypeCode.Enable ? $"#nullable {_nullableFeature.Value.ToString().ToLower()}" : string.Empty;
         public string Annotation => _nullableFeature == NullableFeatureTypeCode.Enable ? "?" : string.Empty;
         public string ForgivingOperator => _nullableFeature == NullableFeatureTypeCode.Enable ? "!" : string.Empty;
 

--- a/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
+++ b/tools/HatTrick.DbEx.Tools/Resources/Templates/Partials/RuntimeDb.htt
@@ -15,7 +15,7 @@
         private static readonly SqlDatabaseMetadataProvider _metadata = new SqlDatabaseMetadataProvider(new {:databaseExpressionName}SqlDatabaseMetadata("{:databaseExpressionName}"));
         private static readonly {$.Platform.Key}FunctionExpressionBuilder _fx = new {$.Platform.Key}FunctionExpressionBuilder();
         private static readonly List<SchemaExpression> _schemas = new List<SchemaExpression>();
-        private static readonly Dictionary<Type, Table> _entityTypeToTableMap = new Dictionary<Type, Table>();
+        private static readonly Dictionary<EntityTypeKey, Table> _entityTypeToTableMap = new Dictionary<EntityTypeKey, Table>();
         private readonly IQueryExpressionBuilderFactory<{:databaseExpressionName}> _queryExpressionBuilderFactory;
         private readonly IDbConnectionFactory _connectionFactory;
         private {:databaseExpressionName}StoredProcedures{:nullableAnnotation} _sp;
@@ -37,7 +37,7 @@
             _schemas.Add({:schemaExpressionName}Schema);
             _{:schemaExpressionName}DataService.{:schemaExpressionName}.UseSchema({$.SchemaExpression.Name}Schema);
             {#each $.Entities}
-            _entityTypeToTableMap.Add(typeof({:schemaExpressionName}Data.{$.EntityExpression.Name}), {:schemaExpressionName}Schema.{$.EntityExpression.Name});
+            _entityTypeToTableMap.Add(new EntityTypeKey(typeof({:schemaExpressionName}Data.{$.EntityExpression.Name}).TypeHandle.Value), {:schemaExpressionName}Schema.{$.EntityExpression.Name});
             {/each}
 
             {/each}
@@ -1371,12 +1371,23 @@
         protected virtual Table<TEntity> GetTable<TEntity>()
             where TEntity : class, IDbEntity
         {{
-            if (!_entityTypeToTableMap.ContainsKey(typeof(TEntity)))
+            if (!_entityTypeToTableMap.TryGetValue(new EntityTypeKey(typeof(TEntity).TypeHandle.Value), out var table))
                 throw new DbExpressionException($"Entity type {{typeof(TEntity)}} is not known.");
-            return _entityTypeToTableMap[typeof(TEntity)] as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {{typeof(TEntity)}}.");
+            return table as Table<TEntity> ?? throw new DbExpressionException($"Map contains an invalid reference for type {{typeof(TEntity)}}.");
         }}
         #endregion
 
 {+>("StoredProcedure") => GetTemplatePartial+}
+
+        #region classes
+        private readonly struct EntityTypeKey : IEquatable<EntityTypeKey>
+        {{
+            public readonly IntPtr Ptr;
+            public EntityTypeKey(IntPtr key) => Ptr = key;
+            public bool Equals(EntityTypeKey other) => Ptr == other.Ptr;
+            public override int GetHashCode() => Ptr.GetHashCode();
+            public override bool Equals(object{:nullableAnnotation} obj) => obj is EntityTypeKey other && Equals(other);
+        }}
+        #endregion
     }}
     #endregion


### PR DESCRIPTION
- Target net6.0 in benchmark project, profiling project, and test projects
- Reworked Appender to use ArrayPool and string.Create for net7.0, eliminated use of StringBuilder
- In AssemblyContext, no longer place defaults in stack for field and entity append styles
- Eliminated internal dictionaries that maintained a type to func map in default factories (now use a IntPtr of the Type as the key):
	- expression element appender factory
	- query expression factory
	- mapper factory
- Use IL generation in default entity factory to instantiate entities when using net5.0 or greater
- Optimized Field and Row by using refs instead of copies for indexes
- Optimized data reader wrappers to use a converter decorator instead of an internal method
- Changed return types from Task<int> to ValueTask<int> for affected row count for deletes and updates