### PR TITLE
Synthetic Aliases

### DIFF
--- a/src/HatTrick.DbEx.MsSql/Assembler/MsSqlInsertQueryExpressionAppender.cs
+++ b/src/HatTrick.DbEx.MsSql/Assembler/MsSqlInsertQueryExpressionAppender.cs
@@ -41,7 +41,15 @@ namespace HatTrick.DbEx.MsSql.Assembler
 
             builder.Appender.Indent().Write("SET NOCOUNT ON;").LineBreak();
             builder.Appender.Indent().Write("MERGE ");
-            builder.AppendElement(expression.Into, context);
+            context.PushEntityAppendStyle(EntityExpressionAppendStyle.Name);
+            try
+            {
+                builder.AppendElement(expression.Into, context);
+            }
+            finally
+            { 
+                context.PopEntityAppendStyle();
+            }
             builder.Appender.Write(" USING (").LineBreak();
 
             builder.Appender.Indent().Write("VALUES").LineBreak().Indentation++;

--- a/src/HatTrick.DbEx.MsSql/Assembler/v2005/MsSqlInsertQueryExpressionAppender.cs
+++ b/src/HatTrick.DbEx.MsSql/Assembler/v2005/MsSqlInsertQueryExpressionAppender.cs
@@ -41,13 +41,23 @@ namespace HatTrick.DbEx.MsSql.Assembler.v2005
 
             builder.Appender.Indent().Write("SET NOCOUNT ON;").LineBreak();
             builder.Appender.Indent().Write("INSERT INTO ");
-            builder.AppendElement(expression.Into, context);
+
+            context.PushEntityAppendStyle(EntityExpressionAppendStyle.Name);
+            try
+            {
+                builder.AppendElement(expression.Into, context);
+            }
+            finally
+            {
+                context.PopEntityAppendStyle();
+            }
+
             builder.Appender.Write(" (").LineBreak();
             builder.Appender.Indentation++;
 
             for (var i = 0; i < inserts.Count; i++)
             {
-                if (identity is object && (inserts[i] as IAssignmentExpressionProvider).Assignee == identity)
+                if (identity is not null && (inserts[i] as IAssignmentExpressionProvider).Assignee == identity)
                     continue; //don't emit identity columns with the values; they can't be inserted into the table
 
                 builder.Appender.Indent();

--- a/src/HatTrick.DbEx.Sql/Assembler/AssemblyContext.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/AssemblyContext.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using HatTrick.DbEx.Sql.Configuration;
+using HatTrick.DbEx.Sql.Expression;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -29,11 +30,10 @@ namespace HatTrick.DbEx.Sql.Assembler
         #region internals
         private readonly Stack<FieldExpressionAppendStyle> fieldStyles = new();
         private readonly Stack<EntityExpressionAppendStyle> entityStyles = new();
-        private readonly IDictionary<Type,object> state = new ConcurrentDictionary<Type,object>();
+        private readonly Dictionary<Type,object> state = new();
         #endregion
 
         #region interface
-        public bool IncludeSchemaName { get; set; } = true;
         public bool PrependCommaOnSelectClause { get; set; } = false;
         public SqlStatementAssemblyOptions.Delimeters IdentifierDelimiter { get; set; } = new SqlStatementAssemblyOptions.Delimeters('[', ']');
         public char StatementTerminator { get; set; } = ';';

--- a/src/HatTrick.DbEx.Sql/Assembler/EntityExpressionAppendStyle.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/EntityExpressionAppendStyle.cs
@@ -22,6 +22,7 @@
     {
         None = 0,
         Declaration = 1,
-        Alias = 2
+        Alias = 2,
+        Name = 3
     }
 }

--- a/src/HatTrick.DbEx.Sql/Assembler/ISqlStatementBuilder.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/ISqlStatementBuilder.cs
@@ -34,6 +34,8 @@ namespace HatTrick.DbEx.Sql.Assembler
         void AppendElement<T>(T element, AssemblyContext context)
             where T : class, IExpressionElement;
         string GenerateAlias();
+        string? ResolveTableAlias(IExpressionElement element);
+        string? ResolveTableAlias(string tableName);
         string GetPlatformName(ISqlMetadataIdentifierProvider identifier);
         ISqlColumnMetadata GetPlatformMetadata(Field field);
         ISqlParameterMetadata GetPlatformMetadata(QueryParameter parameter);

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/AliasExpressionAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/AliasExpressionAppender.cs
@@ -29,7 +29,7 @@ namespace HatTrick.DbEx.Sql.Assembler
             {
                 builder.Appender
                     .Write(context.IdentifierDelimiter.Begin)
-                    .Write(alias.TableAlias!)
+                    .Write(builder.ResolveTableAlias(alias.TableAlias!)!)
                     .Write(context.IdentifierDelimiter.End);
             }
 

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/DeleteQueryExpressionAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/DeleteQueryExpressionAppender.cs
@@ -35,13 +35,21 @@ namespace HatTrick.DbEx.Sql.Assembler
             builder.Appender.LineBreak()
                 .Indentation++.Indent();
 
-            builder.AppendElement(expression.From ?? throw new DbExpressionQueryException(expression, ExceptionMessages.NullValueUnexpected()), context);
+            context.PushEntityAppendStyle(EntityExpressionAppendStyle.Name);
+            try
+            {
+                builder.AppendElement(expression.From ?? throw new DbExpressionQueryException(expression, ExceptionMessages.NullValueUnexpected()), context);
 
-            builder.Appender.LineBreak()
-                .Indentation--.Indent().Write("FROM").LineBreak()
-                .Indentation++.Indent();
+                builder.Appender.LineBreak()
+                    .Indentation--.Indent().Write("FROM").LineBreak()
+                    .Indentation++.Indent();
 
-            builder.AppendElement(expression.From, context);
+                builder.AppendElement(expression.From, context);
+            }
+            finally
+            {
+                context.PopEntityAppendStyle();
+            }
 
             builder.Appender.Indentation--;
 

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/EntityExpressionAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/EntityExpressionAppender.cs
@@ -24,39 +24,32 @@ namespace HatTrick.DbEx.Sql.Assembler
     {
         public override void AppendElement(EntityExpression expression, ISqlStatementBuilder builder, AssemblyContext context)
         {
-            if (context.EntityExpressionAppendStyle == EntityExpressionAppendStyle.Alias)
-            {
-                var alias = (expression as IExpressionAliasProvider).Alias;
-                if (!string.IsNullOrWhiteSpace(alias))
-                {
-                    builder.Appender
-                        .Write(context.IdentifierDelimiter.Begin)
-                        .Write(alias!)
-                        .Write(context.IdentifierDelimiter.End);
-                    return;
-                }
-            }
+            if (context.EntityExpressionAppendStyle == EntityExpressionAppendStyle.None)
+                return;
 
-            if (context.IncludeSchemaName)
+            if (context.EntityExpressionAppendStyle == EntityExpressionAppendStyle.Name)
             {
                 builder.AppendElement((expression as Table).Schema, context);
                 builder.Appender.Write('.')
                     .Write(context.IdentifierDelimiter.Begin)
                     .Write(builder.GetPlatformName(expression))
                     .Write(context.IdentifierDelimiter.End);
+                return;
             }
 
-            AppendAlias(expression, builder, context);
-        }
+            if (context.EntityExpressionAppendStyle == EntityExpressionAppendStyle.Declaration)
+            {
+                builder.AppendElement((expression as Table).Schema, context);
+                builder.Appender.Write('.')
+                    .Write(context.IdentifierDelimiter.Begin)
+                    .Write(builder.GetPlatformName(expression))
+                    .Write(context.IdentifierDelimiter.End)
+                    .Write(" AS ");
+            }
 
-        protected static void AppendAlias(IExpressionAliasProvider aliasable, ISqlStatementBuilder builder, AssemblyContext context)
-        {
-            if (string.IsNullOrWhiteSpace(aliasable.Alias) || context.EntityExpressionAppendStyle != EntityExpressionAppendStyle.Declaration)
-                return;
-
-            builder.Appender.Write(" AS ")
+            builder.Appender
                 .Write(context.IdentifierDelimiter.Begin)
-                .Write(aliasable.Alias!)
+                .Write(builder.ResolveTableAlias(expression)!)
                 .Write(context.IdentifierDelimiter.End);
         }
     }

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/FromExpressionAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/FromExpressionAppender.cs
@@ -29,34 +29,17 @@ namespace HatTrick.DbEx.Sql.Assembler
             else
                 builder.Appender.Indentation++.Indent();
 
+            builder.AppendElement(expression.Expression, context);
 
-            context.PushEntityAppendStyle(EntityExpressionAppendStyle.Declaration);
-            try
-            {
-                builder.AppendElement(expression.Expression, context);
-            }
-            finally
-            {
-                context.PopEntityAppendStyle();
-            }
+            builder.Appender.Indentation--;
 
-
-            if (expression.Expression is QueryExpression)
-                builder.Appender.LineBreak().Indentation--.Write(')');
-            else
-                builder.Appender.Indentation--;
-
-            AppendAlias(expression, builder, context);
-        }
-
-        protected static void AppendAlias(IExpressionAliasProvider aliasable, ISqlStatementBuilder builder, AssemblyContext context)
-        {
-            if (string.IsNullOrWhiteSpace(aliasable.Alias))
+            if (!(expression.Expression is QueryExpression))
                 return;
 
-            builder.Appender.Write(" AS ")
+            builder.Appender.LineBreak()
+                .Write(") AS ")
                 .Write(context.IdentifierDelimiter.Begin)
-                .Write(aliasable.Alias!)
+                .Write(builder.ResolveTableAlias(expression)!)
                 .Write(context.IdentifierDelimiter.End);
         }
     }

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/JoinExpressionAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/JoinExpressionAppender.cs
@@ -40,7 +40,7 @@ namespace HatTrick.DbEx.Sql.Assembler
                 //append the subquery alias
                 builder.Appender.Indentation--.LineBreak().Indent().Write(") AS ")
                     .Write(context.IdentifierDelimiter.Begin)
-                    .Write((expression as IExpressionAliasProvider).Alias!)
+                    .Write(builder.ResolveTableAlias((expression as IExpressionAliasProvider).Alias!)!)
                     .Write(context.IdentifierDelimiter.End)
                     .Write(" ON ");
 
@@ -50,8 +50,14 @@ namespace HatTrick.DbEx.Sql.Assembler
             }
 
             context.PushEntityAppendStyle(EntityExpressionAppendStyle.Declaration);
-            builder.AppendElement(expression.JoinToo, context);
-            context.PopEntityAppendStyle();
+            try
+            {
+                builder.AppendElement(expression.JoinToo, context);
+            }
+            finally
+            {
+                context.PopEntityAppendStyle();
+            }
 
             if (expression.JoinType == JoinOperationExpressionOperator.CROSS)
                 return;

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/SelectExpressionAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/SelectExpressionAppender.cs
@@ -28,8 +28,7 @@ namespace HatTrick.DbEx.Sql.Assembler
         {
             builder.AppendElement(expression.Expression, context);
 
-            var alias = expression as IExpressionAliasProvider;
-            if (alias is not null && !string.IsNullOrWhiteSpace(alias.Alias))
+            if (expression is IExpressionAliasProvider alias && !string.IsNullOrWhiteSpace(alias.Alias))
             {
                 AppendAlias(alias.Alias!, builder, context);
                 return;
@@ -42,7 +41,7 @@ namespace HatTrick.DbEx.Sql.Assembler
                 string? columnName = null;
                 try
                 {
-                    columnName = builder.GetPlatformMetadata(field)?.Name ?? throw new DbExpressionQueryException(expression, ExceptionMessages.MetadataResolution(field.GetType(), (field as IExpressionNameProvider).Name));
+                    columnName = builder.GetPlatformName(field);
                 }
                 catch (DbExpressionMetadataException e)
                 {

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/SelectQueryExpressionAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/SelectQueryExpressionAppender.cs
@@ -74,7 +74,15 @@ namespace HatTrick.DbEx.Sql.Assembler
 
             builder.Appender.LineBreak().Indent().Write("FROM").LineBreak();
 
-            builder.AppendElement(expression.From, context);
+            context.PushEntityAppendStyle(EntityExpressionAppendStyle.Declaration);
+            try
+            {
+                builder.AppendElement(expression.From, context);
+            }
+            finally
+            {
+                context.PopEntityAppendStyle();
+            }
         }
 
         protected virtual void AppendJoinClause(SelectQueryExpression expression, ISqlStatementBuilder builder, AssemblyContext context)

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/StoredProcedureExpressionAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/StoredProcedureExpressionAppender.cs
@@ -24,13 +24,10 @@ namespace HatTrick.DbEx.Sql.Assembler
     {
         public override void AppendElement(StoredProcedureExpression expression, ISqlStatementBuilder builder, AssemblyContext context)
         {
-            if (context.IncludeSchemaName)
-            {
-                builder.AppendElement((expression as StoredProcedure).Schema, context);
-                builder.Appender.Write(".");
-            }
-
+            builder.AppendElement((expression as StoredProcedure).Schema, context);
+            
             builder.Appender
+                .Write(".")
                 .Write(context.IdentifierDelimiter.Begin)
                 .Write(builder.GetPlatformName(expression))
                 .Write(context.IdentifierDelimiter.End);

--- a/src/HatTrick.DbEx.Sql/Assembler/_Appenders/UpdateQueryExpressionAppender.cs
+++ b/src/HatTrick.DbEx.Sql/Assembler/_Appenders/UpdateQueryExpressionAppender.cs
@@ -37,7 +37,7 @@ namespace HatTrick.DbEx.Sql.Assembler
             builder.Appender.LineBreak()
                 .Indentation++.Indent();
 
-            context.PushEntityAppendStyle(EntityExpressionAppendStyle.None);
+            context.PushEntityAppendStyle(EntityExpressionAppendStyle.Name);
             try
             {
                 builder.AppendElement(expression.From ?? throw new DbExpressionQueryException(expression, ExceptionMessages.NullValueUnexpected()), context);

--- a/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/SqlStatementAssemblyOptions.cs
+++ b/src/HatTrick.DbEx.Sql/Configuration/_SqlStatements/SqlStatementAssemblyOptions.cs
@@ -20,7 +20,6 @@
 {
     public class SqlStatementAssemblyOptions
     {
-        public bool IncludeSchemaName { get; set; } = true;
         public bool PrependCommaOnSelectClause { get; set; } = false;
         public Delimeters IdentifierDelimiter { get; set; } = new Delimeters('[', ']');
         public char StatementTerminator { get; set; } = ';';

--- a/src/HatTrick.DbEx.Sql/Expression/AliasExpression.cs
+++ b/src/HatTrick.DbEx.Sql/Expression/AliasExpression.cs
@@ -110,7 +110,7 @@ namespace HatTrick.DbEx.Sql.Expression
         #endregion
 
         #region classes
-        public class AliasExpressionElements : IExpression
+        public class AliasExpressionElements : IExpressionElement
         {
             public string? TableAlias { get; set; }
             public string FieldAlias { get; set; } = string.Empty;

--- a/src/HatTrick.DbEx.Sql/_Extensions/Configuration/SqlStatementAssemblerConfigurationExtensions.cs
+++ b/src/HatTrick.DbEx.Sql/_Extensions/Configuration/SqlStatementAssemblerConfigurationExtensions.cs
@@ -26,7 +26,6 @@ namespace HatTrick.DbEx.Sql.Configuration
         {
             return new()
             {
-                IncludeSchemaName = config.IncludeSchemaName,
                 PrependCommaOnSelectClause = config.PrependCommaOnSelectClause,
                 IdentifierDelimiter = new(config.IdentifierDelimiter.Begin, config.IdentifierDelimiter.End),
                 StatementTerminator = config.StatementTerminator

--- a/test/HatTrick.DbEx.MsSql.Test.Integration/MultipleDatabaseTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Integration/MultipleDatabaseTests.cs
@@ -3,6 +3,7 @@ using DbEx.dboData;
 using DbEx.dboDataService;
 using DbExAlt.DataService;
 using DbExAlt.dboAltData;
+using DbExAlt.dboAltDataService;
 using FluentAssertions;
 using HatTrick.DbEx.MsSql.Test.Executor;
 using HatTrick.DbEx.Sql;
@@ -28,7 +29,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
 
             //when
             var p1 = db.SelectOne<Person>().From(dbo.Person).OrderBy(dbo.Person.Id.Asc()).Execute();
-            var p2 = dbAlt.SelectOne<PersonAlt>().From(dbo.Person).OrderBy(dbo.Person.Id.Asc()).Execute();
+            var p2 = dbAlt.SelectOne<PersonAlt>().From(dboAlt.PersonAlt).OrderBy(dboAlt.PersonAlt.Id.Asc()).Execute();
 
             //then
             p1.Should().NotBeNull();
@@ -48,7 +49,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
 
             //when
             var p1 = mssqldb.SelectOne<Person>().From(dbo.Person).OrderBy(dbo.Person.Id.Asc()).Execute();
-            var p2 = mssqldbAlt.SelectOne<PersonAlt>().From(dbo.Person).OrderBy(dbo.Person.Id.Asc()).Execute();
+            var p2 = mssqldbAlt.SelectOne<PersonAlt>().From(dboAlt.PersonAlt).OrderBy(dboAlt.PersonAlt.Id.Asc()).Execute();
 
             //then
             p1.Should().NotBeNull();
@@ -69,7 +70,7 @@ namespace HatTrick.DbEx.MsSql.Test.Integration
 
             //when
             var p1 = db.SelectOne<Person>().From(dbo.Person).OrderBy(dbo.Person.Id.Asc()).Execute();
-            var p2 = mssqldbAlt.SelectOne<PersonAlt>().From(dbo.Person).OrderBy(dbo.Person.Id.Asc()).Execute();
+            var p2 = mssqldbAlt.SelectOne<PersonAlt>().From(dboAlt.PersonAlt).OrderBy(dboAlt.PersonAlt.Id.Asc()).Execute();
 
             //then
             p1.Should().NotBeNull();

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/Assembler/AssemblyContextAppendStylesTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/Assembler/AssemblyContextAppendStylesTests.cs
@@ -13,7 +13,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Assembler
     {
         [Theory]
         [MsSqlVersions.AllVersions]
-        public void Does_both_field_and_entity_append_styles_set_to_Declaration_append_correctly(int version, string expected = "[dbo].[Person].[Id]")
+        public void Does_both_field_and_entity_append_styles_set_to_Declaration_append_as_expected(int version, string expected = "[dbo].[Person] AS [Person].[Id]")
         {
             //given
             var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
@@ -35,7 +35,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Assembler
 
         [Theory]
         [MsSqlVersions.AllVersions]
-        public void Does_field_style_of_None_and_entity_append_style_of_Declaration_append_correctly(int version, string expected = "[dbo].[Person]")
+        public void Does_field_style_of_None_and_entity_append_style_of_Declaration_append_correctly(int version, string expected = "[dbo].[Person] AS [Person]")
         {
             //given
             var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
@@ -79,7 +79,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Assembler
 
         [Theory]
         [MsSqlVersions.AllVersions]
-        public void Does_both_field_and_entity_append_styles_set_to_None_append_correctly(int version, string expected = "[dbo].[Person]")
+        public void Does_both_field_and_entity_append_styles_set_to_None_append_correctly(int version, string expected = "")
         {
             //given
             var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
@@ -189,7 +189,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Assembler
 
         [Theory]
         [MsSqlVersions.AllVersions]
-        public void Does_field_style_of_Alias_and_entity_append_style_of_Declaration_append_correctly(int version, string fieldAlias = "fieldAlias", string expected = "[dbo].[Person].[Id] AS [fieldAlias]")
+        public void Does_field_style_of_Alias_and_entity_append_style_of_Declaration_append_correctly(int version, string fieldAlias = "fieldAlias", string expected = "[dbo].[Person] AS [Person].[Id] AS [fieldAlias]")
         {
             //given
             var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/Assembler/IdentifierDelimiterAssemblerTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/Assembler/IdentifierDelimiterAssemblerTests.cs
@@ -12,7 +12,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Assembler
     {
         [Theory]
         [MsSqlVersions.AllVersions]
-        public void Does_a_non_default_delimiter_assemble_a_fieldy_expression_correctly(int version, string expected = "{dbo}.{Person}.{Id}")
+        public void Does_a_non_default_delimiter_assemble_a_field_expression_correctly(int version, string expected = "{dbo}.{Person}.{Id}")
         {
             //given
             var (db, serviceProvider) = Configure<MsSqlDb>().ForMsSqlVersion(version);
@@ -21,7 +21,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Assembler
             IExpressionElementAppender appender = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IExpressionElementAppenderFactory>().CreateElementAppender(field.GetType())!;
 
             var context = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<AssemblyContext>();
-            context.PushAppendStyles(EntityExpressionAppendStyle.Declaration, FieldExpressionAppendStyle.Declaration);
+            context.PushAppendStyles(EntityExpressionAppendStyle.Name, FieldExpressionAppendStyle.Declaration);
             context.IdentifierDelimiter.Begin = '{';
             context.IdentifierDelimiter.End = '}';
 
@@ -45,7 +45,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Assembler
             IExpressionElementAppender appender = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<IExpressionElementAppenderFactory>().CreateElementAppender(entity.GetType())!;
 
             var context = serviceProvider.GetServiceProviderFor<MsSqlDb>().GetRequiredService<AssemblyContext>();
-            context.PushAppendStyles(EntityExpressionAppendStyle.Declaration, FieldExpressionAppendStyle.Declaration);
+            context.PushAppendStyles(EntityExpressionAppendStyle.Name, FieldExpressionAppendStyle.Declaration);
             context.IdentifierDelimiter.Begin = '{';
             context.IdentifierDelimiter.End = '}';
 

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/Assembler/WhereClauseAssemblerTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/Assembler/WhereClauseAssemblerTests.cs
@@ -38,7 +38,7 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Assembler
 
             //then
             whereClause.Should().NotBeNullOrWhiteSpace();
-            whereClause.Should().Be($"[sec].[Person].[Id] > @P1");
+            whereClause.Should().Be($"[Person].[Id] > @P1");
 
             builder.Parameters.Parameters.Should().ContainSingle()
                 .Which.Parameter.ParameterName.Should().Be("@P1");

--- a/test/HatTrick.DbEx.MsSql.Test.Unit/Configuration/SqlStatementBuilderConfigurationTests.cs
+++ b/test/HatTrick.DbEx.MsSql.Test.Unit/Configuration/SqlStatementBuilderConfigurationTests.cs
@@ -181,7 +181,17 @@ namespace HatTrick.DbEx.MsSql.Test.Unit.Configuration
                 throw new NotImplementedException();
             }
 
+            public string? ResolveTableAlias(string alias)
+            {
+                throw new NotImplementedException();
+            }
+
             public string GenerateAlias()
+            {
+                throw new NotImplementedException();
+            }
+
+            public string? ResolveTableAlias(IExpressionElement element)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
- Added synthetic aliases for rendering sql statements.  This uses an alias for table names where appropriate
- Deprecated IncludeSchemaName on assembly context.  Should be controlled internally and not provided as an option.